### PR TITLE
feat: implement generateSpecPack and clarify operation terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,3 +68,16 @@ Each PR should include:
 2. Call out assumptions and tradeoffs early.
 3. Keep discussion technical, respectful, and evidence-based.
 4. Prefer explicit decisions over implied intent.
+
+## 10. Terminology Conventions
+Use these terms consistently in code and docs:
+
+- operation:
+  - an internal deterministic workflow component in SpecForge core
+  - examples: `operation.ideaInterview`, `operation.generatePRD`, `operation.generateSpecPack`
+
+- skill:
+  - an external reusable capability plugin sourced from built-ins, verified providers, or user-installed packages
+  - skills are orchestrated through the Skill Registry layer
+
+Do not label internal runtime operations as skills.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ Early development. The repository is currently implementing Phase 1 foundations:
 - policy/config model
 - test and build scaffold
 
+## Internal Operations vs External Skills
+
+SpecForge separates deterministic orchestration logic from reusable capability plugins:
+
+- Internal operations:
+  - deterministic workflow units in the core engine
+  - responsible for artifact generation, validation, planning, decomposition, scheduling, and execution control
+  - implemented under `src/core/operations`
+
+- External skills:
+  - reusable domain-specific capability plugins (built-in, verified provider, or user-installed)
+  - discovered and managed through a Skill Registry / provider layer
+  - selected by policy based on task type, trust, and compatibility
+
+SpecForge orchestrates workflow and safety; skills provide domain expertise.
+It is a structured engineering orchestration layer, not a monolithic domain-expert agent.
+
 ## Tech Stack
 
 - TypeScript

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,45 @@
+# SpecForge Architecture
+
+SpecForge is a deterministic orchestration engine that coordinates artifact-driven engineering workflows.
+
+## 1. Core Engine
+
+Responsibilities:
+- run-state orchestration
+- artifact/version management
+- policy and gate enforcement
+- deterministic planning and execution control
+
+Core runtime logic is implemented as **operations** (internal deterministic units), not external skills.
+
+## 2. Skill Registry
+
+Responsibilities:
+- discover installed skills
+- track provider metadata and trust/verification status
+- expose skill capability contracts (supported domains/task types, input/output shape)
+- support selection policy hooks for recommendation and approval
+
+The registry is provider-agnostic and supports local, internal, and trusted external sources.
+
+## 3. External Skills
+
+External skills are reusable capability plugins that provide domain expertise.
+
+Skill source categories:
+- built-in defaults
+- verified provider/marketplace skills
+- user-installed custom skills
+
+SpecForge orchestrates when and how skills are used; skills do not replace engine policy or safety controls.
+
+## 4. Execution Agents
+
+Execution agents run selected operations and skill-backed tasks under engine policy.
+
+Responsibilities:
+- execute task payloads with provided context packs
+- report structured outputs/errors
+- remain bounded by policy, approvals, and deterministic artifact contracts
+
+The engine remains the source of truth for workflow state, gates, and artifact provenance.

--- a/src/core/contracts/operation.ts
+++ b/src/core/contracts/operation.ts
@@ -1,4 +1,4 @@
-export interface SkillContract<TInputs, TOutputs> {
+export interface OperationContract<TInputs, TOutputs> {
   name: string;
   version: string;
   purpose: string;

--- a/src/core/operations/generatePRD.ts
+++ b/src/core/operations/generatePRD.ts
@@ -7,7 +7,7 @@ import {
   createNextArtifactMetadata
 } from "../artifacts/versioning.js";
 import type { ProjectMode } from "../contracts/domain.js";
-import type { SkillContract } from "../contracts/skill.js";
+import type { OperationContract } from "../contracts/operation.js";
 import type { PrdSectionId, ValidationIssue } from "../spec/contracts.js";
 import { PRD_REQUIRED_SECTIONS } from "../spec/contracts.js";
 import { validateRequiredSections } from "../spec/validation.js";
@@ -72,8 +72,8 @@ export interface GeneratePrdResult {
   validation_issues: ValidationIssue[];
 }
 
-export const GENERATE_PRD_SKILL_CONTRACT: SkillContract<GeneratePrdInput, GeneratePrdResult> = {
-  name: "skill.generatePRD",
+export const GENERATE_PRD_OPERATION_CONTRACT: OperationContract<GeneratePrdInput, GeneratePrdResult> = {
+  name: "operation.generatePRD",
   version: "v1",
   purpose: "Generate PRD artifacts from an approved or accepted idea brief.",
   inputs_schema: {} as GeneratePrdInput,
@@ -266,7 +266,7 @@ function createPrdMetadata(input: CreatePrdMetadataInput): ArtifactMetadata {
   if (!input.previous_version) {
     return createInitialArtifactMetadata({
       artifactId: input.artifact_id,
-      generator: "skill.generatePRD",
+      generator: "operation.generatePRD",
       sourceRefs: input.source_refs,
       content: input.content,
       ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
@@ -278,11 +278,11 @@ function createPrdMetadata(input: CreatePrdMetadataInput): ArtifactMetadata {
       artifact_id: input.artifact_id,
       artifact_version: input.previous_version,
       created_timestamp: "1970-01-01T00:00:00.000Z",
-      generator: "skill.generatePRD",
+      generator: "operation.generatePRD",
       source_refs: input.source_refs,
       checksum: "0".repeat(64)
     },
-    generator: "skill.generatePRD",
+    generator: "operation.generatePRD",
     sourceRefs: input.source_refs,
     content: input.content,
     ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})

--- a/src/core/operations/generateSpecPack.ts
+++ b/src/core/operations/generateSpecPack.ts
@@ -1,0 +1,567 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ArtifactMetadata, ArtifactSourceRef, ArtifactVersion } from "../artifacts/types.js";
+import {
+  createInitialArtifactMetadata,
+  createNextArtifactMetadata
+} from "../artifacts/versioning.js";
+import type { ProjectMode } from "../contracts/domain.js";
+import type { OperationContract } from "../contracts/operation.js";
+import type { PrdSectionId, SpecSectionId, ValidationIssue } from "../spec/contracts.js";
+import { PRD_REQUIRED_SECTIONS, SPEC_REQUIRED_SECTIONS } from "../spec/contracts.js";
+import { validateRequiredSections } from "../spec/validation.js";
+import type { IdeaBriefArtifact } from "./ideaInterview.js";
+import type { PrdJsonArtifact } from "./generatePRD.js";
+
+const SPEC_MARKDOWN_FILENAME = "SPEC.md";
+const SCHEMA_FILENAME = "core.schema.json";
+const ACCEPTANCE_FILENAME = "core.md";
+const DECISIONS_FILENAME = "decisions.md";
+const INDEX_FILENAME = "index.json";
+const DAG_FILENAME = "dag.yaml";
+
+export type GenerateSpecPackErrorCode =
+  | "insufficient_idea_brief"
+  | "insufficient_prd"
+  | "invalid_mode"
+  | "artifact_write_failed";
+
+export class GenerateSpecPackError extends Error {
+  readonly code: GenerateSpecPackErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: GenerateSpecPackErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "GenerateSpecPackError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface GenerateSpecPackInput {
+  project_mode: ProjectMode;
+  idea_brief?: IdeaBriefArtifact;
+  prd_json?: PrdJsonArtifact;
+  artifact_dir?: string;
+  created_timestamp?: Date;
+}
+
+export interface SpecMarkdownArtifact {
+  kind: "spec_markdown";
+  metadata: ArtifactMetadata;
+  source_refs: ArtifactSourceRef[];
+  project_mode: ProjectMode;
+  sections: Record<SpecSectionId, string>;
+  content: string;
+}
+
+export interface SpecFileArtifact {
+  kind: "schema_json" | "acceptance_markdown" | "decisions_markdown" | "dag_yaml";
+  metadata: ArtifactMetadata;
+  source_refs: ArtifactSourceRef[];
+  path: string;
+  content: string;
+}
+
+export interface SpecIndexEntry {
+  artifact_id: string;
+  artifact_version: ArtifactVersion;
+  path: string;
+  checksum: string;
+  source_refs: ArtifactSourceRef[];
+}
+
+export interface SpecIndexArtifact {
+  kind: "spec_index";
+  metadata: ArtifactMetadata;
+  source_refs: ArtifactSourceRef[];
+  entries: SpecIndexEntry[];
+}
+
+export interface GenerateSpecPackResult {
+  spec_artifact: {
+    kind: "spec";
+    metadata: ArtifactMetadata;
+    sections: Record<SpecSectionId, string>;
+    source_refs: ArtifactSourceRef[];
+  };
+  spec_md: SpecMarkdownArtifact;
+  schema_artifact: SpecFileArtifact;
+  acceptance_artifact: SpecFileArtifact;
+  decisions_artifact: SpecFileArtifact;
+  dag_artifact: SpecFileArtifact;
+  spec_index: SpecIndexArtifact;
+  validation_issues: ValidationIssue[];
+}
+
+export const GENERATE_SPEC_PACK_OPERATION_CONTRACT: OperationContract<
+  GenerateSpecPackInput,
+  GenerateSpecPackResult
+> = {
+  name: "operation.generateSpecPack",
+  version: "v1",
+  purpose: "Generate deterministic contract-first spec artifacts from idea_brief and PRD.",
+  inputs_schema: {} as GenerateSpecPackInput,
+  outputs_schema: {} as GenerateSpecPackResult,
+  side_effects: ["writes SPEC.md, schema, acceptance, decisions, index, and initial DAG artifacts"],
+  invariants: [
+    "Spec pack output is deterministic for equivalent inputs.",
+    "SPEC required sections are always validated.",
+    "Artifacts reference exact source versions."
+  ],
+  idempotency_expectations: [
+    "Generated section structure and index order are stable across runs."
+  ],
+  failure_modes: ["insufficient_idea_brief", "insufficient_prd", "invalid_mode", "artifact_write_failed"],
+  observability_fields: [
+    "project_mode",
+    "idea_brief_version",
+    "prd_version",
+    "spec_version",
+    "validation_issue_count"
+  ]
+};
+
+export async function runGenerateSpecPack(
+  input: GenerateSpecPackInput
+): Promise<GenerateSpecPackResult> {
+  const ideaBrief = ensureIdeaBrief(input.idea_brief);
+  const prdJson = ensurePrdJson(input.prd_json);
+
+  if (ideaBrief.project_mode !== input.project_mode || prdJson.project_mode !== input.project_mode) {
+    throw new GenerateSpecPackError(
+      "invalid_mode",
+      "idea_brief/project_mode/prd_json mode mismatch."
+    );
+  }
+
+  const sections = buildSpecSections(prdJson);
+  const sourceRefs: ArtifactSourceRef[] = [
+    {
+      artifact_id: ideaBrief.metadata.artifact_id,
+      artifact_version: ideaBrief.metadata.artifact_version
+    },
+    {
+      artifact_id: prdJson.metadata.artifact_id,
+      artifact_version: prdJson.metadata.artifact_version
+    }
+  ];
+
+  const previousVersion = await readExistingSpecVersion(input.artifact_dir);
+  const specMarkdownContent = renderSpecMarkdown(sections);
+
+  const specMetadata = createSpecMetadata({
+    artifact_id: "spec.md",
+    content: specMarkdownContent,
+    source_refs: sourceRefs,
+    ...(previousVersion ? { previous_version: previousVersion } : {}),
+    ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+  });
+
+  const spec_artifact = {
+    kind: "spec" as const,
+    metadata: specMetadata,
+    sections,
+    source_refs: sourceRefs
+  };
+
+  const validationIssues = validateRequiredSections(spec_artifact);
+  if (validationIssues.length > 0) {
+    throw new GenerateSpecPackError(
+      "insufficient_prd",
+      "Generated SPEC is missing required sections.",
+      validationIssues
+    );
+  }
+
+  const schemaContent = renderSchemaContent(prdJson);
+  const acceptanceContent = renderAcceptanceContent(sections.acceptance_criteria);
+  const decisionsContent = renderDecisionsContent(sections.decisions);
+  const dagContent = renderInitialDag();
+
+  const schemaArtifact: SpecFileArtifact = {
+    kind: "schema_json",
+    metadata: createSpecMetadata({
+      artifact_id: "schema.core",
+      content: schemaContent,
+      source_refs: sourceRefs,
+      ...(previousVersion ? { previous_version: previousVersion } : {}),
+      ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+    }),
+    source_refs: sourceRefs,
+    path: "schemas/core.schema.json",
+    content: schemaContent
+  };
+
+  const acceptanceArtifact: SpecFileArtifact = {
+    kind: "acceptance_markdown",
+    metadata: createSpecMetadata({
+      artifact_id: "acceptance.core",
+      content: acceptanceContent,
+      source_refs: sourceRefs,
+      ...(previousVersion ? { previous_version: previousVersion } : {}),
+      ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+    }),
+    source_refs: sourceRefs,
+    path: "acceptance/core.md",
+    content: acceptanceContent
+  };
+
+  const decisionsArtifact: SpecFileArtifact = {
+    kind: "decisions_markdown",
+    metadata: createSpecMetadata({
+      artifact_id: "decisions.md",
+      content: decisionsContent,
+      source_refs: sourceRefs,
+      ...(previousVersion ? { previous_version: previousVersion } : {}),
+      ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+    }),
+    source_refs: sourceRefs,
+    path: "decisions.md",
+    content: decisionsContent
+  };
+
+  const dagArtifact: SpecFileArtifact = {
+    kind: "dag_yaml",
+    metadata: createSpecMetadata({
+      artifact_id: "dag.yaml",
+      content: dagContent,
+      source_refs: sourceRefs,
+      ...(previousVersion ? { previous_version: previousVersion } : {}),
+      ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+    }),
+    source_refs: sourceRefs,
+    path: "spec/dag.yaml",
+    content: dagContent
+  };
+
+  const spec_md: SpecMarkdownArtifact = {
+    kind: "spec_markdown",
+    metadata: specMetadata,
+    source_refs: sourceRefs,
+    project_mode: input.project_mode,
+    sections,
+    content: specMarkdownContent
+  };
+
+  const indexEntries: SpecIndexEntry[] = [
+    {
+      artifact_id: spec_md.metadata.artifact_id,
+      artifact_version: spec_md.metadata.artifact_version,
+      path: "SPEC.md",
+      checksum: spec_md.metadata.checksum,
+      source_refs: sourceRefs
+    },
+    {
+      artifact_id: schemaArtifact.metadata.artifact_id,
+      artifact_version: schemaArtifact.metadata.artifact_version,
+      path: schemaArtifact.path,
+      checksum: schemaArtifact.metadata.checksum,
+      source_refs: sourceRefs
+    },
+    {
+      artifact_id: acceptanceArtifact.metadata.artifact_id,
+      artifact_version: acceptanceArtifact.metadata.artifact_version,
+      path: acceptanceArtifact.path,
+      checksum: acceptanceArtifact.metadata.checksum,
+      source_refs: sourceRefs
+    },
+    {
+      artifact_id: decisionsArtifact.metadata.artifact_id,
+      artifact_version: decisionsArtifact.metadata.artifact_version,
+      path: decisionsArtifact.path,
+      checksum: decisionsArtifact.metadata.checksum,
+      source_refs: sourceRefs
+    },
+    {
+      artifact_id: dagArtifact.metadata.artifact_id,
+      artifact_version: dagArtifact.metadata.artifact_version,
+      path: dagArtifact.path,
+      checksum: dagArtifact.metadata.checksum,
+      source_refs: sourceRefs
+    }
+  ];
+
+  const specIndexContent = JSON.stringify({ entries: indexEntries }, null, 2);
+  const spec_index: SpecIndexArtifact = {
+    kind: "spec_index",
+    metadata: createSpecMetadata({
+      artifact_id: "spec.index",
+      content: specIndexContent,
+      source_refs: sourceRefs,
+      ...(previousVersion ? { previous_version: previousVersion } : {}),
+      ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+    }),
+    source_refs: sourceRefs,
+    entries: indexEntries
+  };
+
+  if (input.artifact_dir) {
+    await writeSpecPackArtifacts({
+      artifact_dir: input.artifact_dir,
+      spec_md,
+      schema_artifact: schemaArtifact,
+      acceptance_artifact: acceptanceArtifact,
+      decisions_artifact: decisionsArtifact,
+      dag_artifact: dagArtifact,
+      spec_index
+    });
+  }
+
+  return {
+    spec_artifact,
+    spec_md,
+    schema_artifact: schemaArtifact,
+    acceptance_artifact: acceptanceArtifact,
+    decisions_artifact: decisionsArtifact,
+    dag_artifact: dagArtifact,
+    spec_index,
+    validation_issues: validationIssues
+  };
+}
+
+function ensureIdeaBrief(artifact?: IdeaBriefArtifact): IdeaBriefArtifact {
+  if (!artifact || artifact.kind !== "idea_brief") {
+    throw new GenerateSpecPackError("insufficient_idea_brief", "Missing or invalid idea_brief artifact.");
+  }
+
+  if (artifact.metadata.artifact_id !== "idea_brief") {
+    throw new GenerateSpecPackError("insufficient_idea_brief", "idea_brief artifact_id must be idea_brief.");
+  }
+
+  return artifact;
+}
+
+function ensurePrdJson(artifact?: PrdJsonArtifact): PrdJsonArtifact {
+  if (!artifact || artifact.kind !== "prd_json") {
+    throw new GenerateSpecPackError("insufficient_prd", "Missing or invalid prd_json artifact.");
+  }
+
+  if (artifact.metadata.artifact_id !== "prd.json") {
+    throw new GenerateSpecPackError("insufficient_prd", "prd_json artifact_id must be prd.json.");
+  }
+
+  for (const sectionId of PRD_REQUIRED_SECTIONS) {
+    const value = normalizeText(artifact.sections[sectionId]);
+    if (value.length === 0) {
+      throw new GenerateSpecPackError("insufficient_prd", `PRD section is missing: ${sectionId}`);
+    }
+  }
+
+  return artifact;
+}
+
+function buildSpecSections(prd: PrdJsonArtifact): Record<SpecSectionId, string> {
+  return {
+    summary: prd.sections.outcome,
+    scope:
+      `Users/Roles: ${prd.sections.users_roles}\n\n` +
+      `Non-goals: ${prd.sections.non_goals}`,
+    contracts:
+      `Interfaces: ${prd.sections.interfaces}\n\n` +
+      `Inputs: ${prd.sections.inputs}\n\n` +
+      `Outputs: ${prd.sections.outputs}`,
+    acceptance_criteria:
+      `Evaluation: ${prd.sections.evaluation}\n\n` +
+      `Quality Bar: ${prd.sections.quality_bar}`,
+    decisions:
+      `Failure Modes: ${prd.sections.failure_modes}\n\n` +
+      `Operations: ${prd.sections.operations}`,
+    work_graph: "See spec/dag.yaml for the initial EPIC/STORY/TASK work graph."
+  };
+}
+
+function renderSpecMarkdown(sections: Record<SpecSectionId, string>): string {
+  const titleBySection: Record<SpecSectionId, string> = {
+    summary: "Summary",
+    scope: "Scope",
+    contracts: "Contracts",
+    acceptance_criteria: "Acceptance Criteria",
+    decisions: "Decisions",
+    work_graph: "Work Graph"
+  };
+
+  const lines: string[] = ["# Specification", ""];
+
+  for (const sectionId of SPEC_REQUIRED_SECTIONS) {
+    lines.push(`## ${titleBySection[sectionId]}`);
+    lines.push(sections[sectionId]);
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function renderSchemaContent(prd: PrdJsonArtifact): string {
+  const schema = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    title: "SpecForgeCoreContract",
+    type: "object",
+    additionalProperties: false,
+    required: ["inputs", "outputs"],
+    properties: {
+      inputs: {
+        type: "string",
+        description: prd.sections.inputs
+      },
+      outputs: {
+        type: "string",
+        description: prd.sections.outputs
+      }
+    }
+  };
+
+  return JSON.stringify(schema, null, 2);
+}
+
+function renderAcceptanceContent(acceptanceCriteriaSection: string): string {
+  return ["# Acceptance Criteria", "", acceptanceCriteriaSection].join("\n");
+}
+
+function renderDecisionsContent(decisionsSection: string): string {
+  return ["# Decisions", "", decisionsSection].join("\n");
+}
+
+function renderInitialDag(): string {
+  return [
+    "epics:",
+    "  - id: EPIC-1",
+    "    title: Deliver initial spec artifacts",
+    "    stories:",
+    "      - id: STORY-1",
+    "        title: Validate contracts and acceptance artifacts",
+    "        tasks:",
+    "          - id: TASK-1",
+    "            title: Verify schema and acceptance coverage",
+    "            acceptance_ref: acceptance/core.md",
+    "            contract_ref: schemas/core.schema.json"
+  ].join("\n");
+}
+
+interface CreateSpecMetadataInput {
+  artifact_id:
+    | "spec.md"
+    | "schema.core"
+    | "acceptance.core"
+    | "decisions.md"
+    | "spec.index"
+    | "dag.yaml";
+  content: string;
+  source_refs: ArtifactSourceRef[];
+  previous_version?: ArtifactVersion;
+  created_timestamp?: Date;
+}
+
+function createSpecMetadata(input: CreateSpecMetadataInput): ArtifactMetadata {
+  if (!input.previous_version) {
+    return createInitialArtifactMetadata({
+      artifactId: input.artifact_id,
+      generator: "operation.generateSpecPack",
+      sourceRefs: input.source_refs,
+      content: input.content,
+      ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
+    });
+  }
+
+  return createNextArtifactMetadata({
+    previous: {
+      artifact_id: input.artifact_id,
+      artifact_version: input.previous_version,
+      created_timestamp: "1970-01-01T00:00:00.000Z",
+      generator: "operation.generateSpecPack",
+      source_refs: input.source_refs,
+      checksum: "0".repeat(64)
+    },
+    generator: "operation.generateSpecPack",
+    sourceRefs: input.source_refs,
+    content: input.content,
+    ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
+  });
+}
+
+async function readExistingSpecVersion(artifactDir?: string): Promise<ArtifactVersion | undefined> {
+  if (!artifactDir) {
+    return undefined;
+  }
+
+  try {
+    const raw = await readFile(join(artifactDir, "spec", INDEX_FILENAME), "utf8");
+    const parsed = JSON.parse(raw) as Partial<SpecIndexArtifact>;
+    const version = parsed.metadata?.artifact_version;
+
+    if (typeof version === "string" && /^v\d+$/.test(version)) {
+      return version as ArtifactVersion;
+    }
+
+    throw new GenerateSpecPackError(
+      "artifact_write_failed",
+      "Existing spec/index.json has invalid metadata.artifact_version."
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+
+    if (error instanceof GenerateSpecPackError) {
+      throw error;
+    }
+
+    throw new GenerateSpecPackError(
+      "artifact_write_failed",
+      "Unable to inspect existing spec/index.json artifact."
+    );
+  }
+}
+
+interface WriteSpecPackArtifactsInput {
+  artifact_dir: string;
+  spec_md: SpecMarkdownArtifact;
+  schema_artifact: SpecFileArtifact;
+  acceptance_artifact: SpecFileArtifact;
+  decisions_artifact: SpecFileArtifact;
+  dag_artifact: SpecFileArtifact;
+  spec_index: SpecIndexArtifact;
+}
+
+async function writeSpecPackArtifacts(input: WriteSpecPackArtifactsInput): Promise<void> {
+  try {
+    await mkdir(join(input.artifact_dir, "schemas"), { recursive: true });
+    await mkdir(join(input.artifact_dir, "acceptance"), { recursive: true });
+    await mkdir(join(input.artifact_dir, "spec"), { recursive: true });
+
+    await writeFile(join(input.artifact_dir, SPEC_MARKDOWN_FILENAME), `${input.spec_md.content}\n`, "utf8");
+    await writeFile(
+      join(input.artifact_dir, "schemas", SCHEMA_FILENAME),
+      `${input.schema_artifact.content}\n`,
+      "utf8"
+    );
+    await writeFile(
+      join(input.artifact_dir, "acceptance", ACCEPTANCE_FILENAME),
+      `${input.acceptance_artifact.content}\n`,
+      "utf8"
+    );
+    await writeFile(
+      join(input.artifact_dir, DECISIONS_FILENAME),
+      `${input.decisions_artifact.content}\n`,
+      "utf8"
+    );
+    await writeFile(
+      join(input.artifact_dir, "spec", DAG_FILENAME),
+      `${input.dag_artifact.content}\n`,
+      "utf8"
+    );
+    await writeFile(
+      join(input.artifact_dir, "spec", INDEX_FILENAME),
+      `${JSON.stringify(input.spec_index, null, 2)}\n`,
+      "utf8"
+    );
+  } catch {
+    throw new GenerateSpecPackError("artifact_write_failed", "Failed to write spec pack artifacts.");
+  }
+}
+
+function normalizeText(value?: string): string {
+  return (value ?? "").trim();
+}
+

--- a/src/core/operations/ideaInterview.ts
+++ b/src/core/operations/ideaInterview.ts
@@ -7,7 +7,7 @@ import {
   createNextArtifactMetadata
 } from "../artifacts/versioning.js";
 import type { ProjectMode } from "../contracts/domain.js";
-import type { SkillContract } from "../contracts/skill.js";
+import type { OperationContract } from "../contracts/operation.js";
 
 export const IDEA_BUCKET_IDS = [
   "outcome",
@@ -160,11 +160,11 @@ const AMBIGUOUS_ANSWER_PATTERNS = [
 const DEFAULT_MAX_QUESTIONS_PER_ROUND = 10;
 const IDEA_BRIEF_FILENAME = "idea_brief.json";
 
-export const IDEA_INTERVIEW_SKILL_CONTRACT: SkillContract<
+export const IDEA_INTERVIEW_OPERATION_CONTRACT: OperationContract<
   IdeaInterviewInput,
   IdeaInterviewResult
 > = {
-  name: "skill.ideaInterview",
+  name: "operation.ideaInterview",
   version: "v1",
   purpose: "Clarify user intent into a structured idea brief artifact.",
   inputs_schema: {} as IdeaInterviewInput,
@@ -279,14 +279,14 @@ async function writeIdeaBriefArtifact(input: WriteIdeaBriefArtifactInput): Promi
   const metadata = existingArtifact
     ? createNextArtifactMetadata({
         previous: existingArtifact.metadata,
-        generator: "skill.ideaInterview",
+        generator: "operation.ideaInterview",
         sourceRefs: [],
         content: serializedContent,
         ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
       })
     : createInitialArtifactMetadata({
         artifactId: "idea_brief",
-        generator: "skill.ideaInterview",
+        generator: "operation.ideaInterview",
         sourceRefs: [],
         content: serializedContent,
         ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})

--- a/src/core/spec/ownership.ts
+++ b/src/core/spec/ownership.ts
@@ -9,25 +9,25 @@ export type ArtifactKind = (typeof ARTIFACT_KINDS)[number];
 
 export interface ArtifactOwnershipContract {
   artifact_kind: ArtifactKind;
-  owner_skill: string;
+  owner_operation: string;
 }
 
 export const ARTIFACT_OWNERSHIP_REGISTRY: Record<ArtifactKind, ArtifactOwnershipContract> = {
   idea_brief: {
     artifact_kind: "idea_brief",
-    owner_skill: "skill.ideaInterview"
+    owner_operation: "operation.ideaInterview"
   },
   prd: {
     artifact_kind: "prd",
-    owner_skill: "skill.generatePRD"
+    owner_operation: "operation.generatePRD"
   },
   spec: {
     artifact_kind: "spec",
-    owner_skill: "skill.generateSpecPack"
+    owner_operation: "operation.generateSpecPack"
   },
   validation_report: {
     artifact_kind: "validation_report",
-    owner_skill: "skill.validateSpecPack"
+    owner_operation: "operation.validateSpecPack"
   }
 };
 
@@ -54,4 +54,3 @@ export function inferArtifactKindFromId(artifactId: string): ArtifactKind | unde
 export function isOwnedArtifactKind(kind: string): kind is ArtifactKind {
   return ARTIFACT_KINDS.includes(kind as ArtifactKind);
 }
-

--- a/tests/core/artifact-versioning.test.ts
+++ b/tests/core/artifact-versioning.test.ts
@@ -13,7 +13,7 @@ describe("artifact versioning invariants", () => {
     const content = JSON.stringify({ data: "v1" });
     const created = createInitialArtifactMetadata({
       artifactId: "spec.index",
-      generator: "skill.generateSpecPack",
+      generator: "operation.generateSpecPack",
       sourceRefs: [],
       content
     });
@@ -24,7 +24,7 @@ describe("artifact versioning invariants", () => {
     expect(created.created_timestamp).toMatch(
       /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
     );
-    expect(created.generator).toBe("skill.generateSpecPack");
+    expect(created.generator).toBe("operation.generateSpecPack");
     expect(created.source_refs).toEqual([]);
     expect(created.checksum).toHaveLength(64);
   });
@@ -32,14 +32,14 @@ describe("artifact versioning invariants", () => {
   it("increments versions and records parent version for derived artifacts", () => {
     const v1 = createInitialArtifactMetadata({
       artifactId: "prd.main",
-      generator: "skill.generatePRD",
+      generator: "operation.generatePRD",
       sourceRefs: [],
       content: "first"
     });
 
     const v2 = createNextArtifactMetadata({
       previous: v1,
-      generator: "skill.generatePRD",
+      generator: "operation.generatePRD",
       sourceRefs: [{ artifact_id: "idea_brief", artifact_version: "v1" }],
       content: "second"
     });

--- a/tests/idea-interview/idea-interview.test.ts
+++ b/tests/idea-interview/idea-interview.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   IDEA_BUCKET_DEFINITIONS,
   runIdeaInterview
-} from "../../src/core/skills/ideaInterview.js";
+} from "../../src/core/operations/ideaInterview.js";
 
 function buildCompleteAnswers(): Record<string, string> {
   const answers: Record<string, string> = {};
@@ -119,7 +119,7 @@ describe("idea_brief artifact publishing", () => {
     expect(first.artifact?.metadata.artifact_id).toBe("idea_brief");
     expect(first.artifact?.metadata.artifact_version).toBe("v1");
     expect(first.artifact?.metadata.parent_version).toBeUndefined();
-    expect(first.artifact?.metadata.generator).toBe("skill.ideaInterview");
+    expect(first.artifact?.metadata.generator).toBe("operation.ideaInterview");
     expect(first.artifact?.metadata.created_timestamp).toBe("2026-03-08T12:00:00.000Z");
     expect(first.artifact?.metadata.checksum).toHaveLength(64);
 

--- a/tests/prd/generate-prd.test.ts
+++ b/tests/prd/generate-prd.test.ts
@@ -4,11 +4,11 @@ import { tmpdir } from "node:os";
 
 import { describe, expect, it } from "vitest";
 
-import type { IdeaBriefArtifact } from "../../src/core/skills/ideaInterview.js";
+import type { IdeaBriefArtifact } from "../../src/core/operations/ideaInterview.js";
 import {
   GeneratePrdError,
   runGeneratePrd
-} from "../../src/core/skills/generatePRD.js";
+} from "../../src/core/operations/generatePRD.js";
 import { PRD_REQUIRED_SECTIONS } from "../../src/core/spec/contracts.js";
 
 function buildIdeaBrief(overrides?: Partial<IdeaBriefArtifact>): IdeaBriefArtifact {
@@ -33,7 +33,7 @@ function buildIdeaBrief(overrides?: Partial<IdeaBriefArtifact>): IdeaBriefArtifa
       artifact_id: "idea_brief",
       artifact_version: "v1",
       created_timestamp: "2026-03-08T00:00:00.000Z",
-      generator: "skill.ideaInterview",
+      generator: "operation.ideaInterview",
       source_refs: [],
       checksum: "0".repeat(64)
     },

--- a/tests/spec/generate-spec-pack.test.ts
+++ b/tests/spec/generate-spec-pack.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import type { IdeaBriefArtifact } from "../../src/core/operations/ideaInterview.js";
+import type { PrdJsonArtifact } from "../../src/core/operations/generatePRD.js";
+import {
+  GenerateSpecPackError,
+  runGenerateSpecPack
+} from "../../src/core/operations/generateSpecPack.js";
+import { PRD_REQUIRED_SECTIONS, SPEC_REQUIRED_SECTIONS } from "../../src/core/spec/contracts.js";
+
+function buildIdeaBrief(overrides?: Partial<IdeaBriefArtifact>): IdeaBriefArtifact {
+  return {
+    kind: "idea_brief",
+    metadata: {
+      artifact_id: "idea_brief",
+      artifact_version: "v2",
+      created_timestamp: "2026-03-11T00:00:00.000Z",
+      generator: "operation.ideaInterview",
+      source_refs: [],
+      checksum: "a".repeat(64)
+    },
+    project_mode: "greenfield",
+    buckets: {
+      outcome: "Deliver contract-first planning artifacts.",
+      users_roles: "Maintainers and contributors.",
+      non_goals: "No distributed execution in v1.",
+      inputs: "Approved idea and PRD artifacts.",
+      outputs: "Spec pack and plan artifacts.",
+      workflow: "Interview -> PRD -> Spec Pack.",
+      interfaces: "CLI + artifact contracts.",
+      quality_bar: "Deterministic output with tests.",
+      safety_compliance: "Safe defaults and explicit gates.",
+      failure_modes: "Missing source artifacts.",
+      evaluation: "All tests pass.",
+      operations: "Local-first CLI execution."
+    },
+    unresolved_assumptions: [],
+    ...overrides
+  };
+}
+
+function buildPrdJson(overrides?: Partial<PrdJsonArtifact>): PrdJsonArtifact {
+  const sections = {} as Record<(typeof PRD_REQUIRED_SECTIONS)[number], string>;
+  for (const sectionId of PRD_REQUIRED_SECTIONS) {
+    sections[sectionId] = `Content for ${sectionId}`;
+  }
+
+  return {
+    kind: "prd_json",
+    metadata: {
+      artifact_id: "prd.json",
+      artifact_version: "v1",
+      created_timestamp: "2026-03-11T00:10:00.000Z",
+      generator: "operation.generatePRD",
+      source_refs: [{ artifact_id: "idea_brief", artifact_version: "v2" }],
+      checksum: "b".repeat(64)
+    },
+    source_refs: [{ artifact_id: "idea_brief", artifact_version: "v2" }],
+    project_mode: "greenfield",
+    sections,
+    unresolved_assumptions: [],
+    ...overrides
+  };
+}
+
+describe("generateSpecPack failure paths", () => {
+  it("fails with typed error when idea_brief is missing", async () => {
+    await expect(
+      runGenerateSpecPack({
+        project_mode: "greenfield",
+        prd_json: buildPrdJson()
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<GenerateSpecPackError>>({
+        code: "insufficient_idea_brief"
+      })
+    );
+  });
+
+  it("fails with typed error when prd_json is missing", async () => {
+    await expect(
+      runGenerateSpecPack({
+        project_mode: "greenfield",
+        idea_brief: buildIdeaBrief()
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<GenerateSpecPackError>>({
+        code: "insufficient_prd"
+      })
+    );
+  });
+});
+
+describe("generateSpecPack success paths", () => {
+  it("produces deterministic required artifact set and required SPEC section structure", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-spec-pack-"));
+
+    const result = await runGenerateSpecPack({
+      project_mode: "greenfield",
+      idea_brief: buildIdeaBrief(),
+      prd_json: buildPrdJson(),
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-11T12:00:00.000Z")
+    });
+
+    expect(Object.keys(result.spec_artifact.sections)).toEqual([...SPEC_REQUIRED_SECTIONS]);
+    expect(result.validation_issues).toEqual([]);
+
+    expect(result.spec_md.metadata.artifact_id).toBe("spec.md");
+    expect(result.spec_md.metadata.artifact_version).toBe("v1");
+    expect(result.spec_index.metadata.artifact_id).toBe("spec.index");
+    expect(result.spec_index.metadata.artifact_version).toBe("v1");
+
+    const indexPaths = result.spec_index.entries.map((entry) => entry.path);
+    expect(indexPaths).toEqual([
+      "SPEC.md",
+      "schemas/core.schema.json",
+      "acceptance/core.md",
+      "decisions.md",
+      "spec/dag.yaml"
+    ]);
+
+    const specMd = await readFile(join(artifactDir, "SPEC.md"), "utf8");
+    expect(specMd.startsWith("# Specification\n")).toBe(true);
+    expect(specMd).toContain("## Summary");
+    expect(specMd).toContain("## Work Graph");
+
+    const schemaJson = JSON.parse(
+      await readFile(join(artifactDir, "schemas", "core.schema.json"), "utf8")
+    );
+    expect(schemaJson.title).toBe("SpecForgeCoreContract");
+
+    const indexJson = JSON.parse(await readFile(join(artifactDir, "spec", "index.json"), "utf8"));
+    expect(indexJson.metadata.artifact_id).toBe("spec.index");
+
+    const dagYaml = await readFile(join(artifactDir, "spec", "dag.yaml"), "utf8");
+    expect(dagYaml).toContain("EPIC-1");
+  });
+
+  it("increments artifact versions on subsequent runs", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-spec-pack-"));
+
+    await runGenerateSpecPack({
+      project_mode: "greenfield",
+      idea_brief: buildIdeaBrief(),
+      prd_json: buildPrdJson(),
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-11T12:00:00.000Z")
+    });
+
+    const second = await runGenerateSpecPack({
+      project_mode: "greenfield",
+      idea_brief: buildIdeaBrief(),
+      prd_json: buildPrdJson(),
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-11T12:10:00.000Z")
+    });
+
+    expect(second.spec_md.metadata.artifact_version).toBe("v2");
+    expect(second.spec_md.metadata.parent_version).toBe("v1");
+    expect(second.spec_index.metadata.artifact_version).toBe("v2");
+    expect(second.spec_index.metadata.parent_version).toBe("v1");
+  });
+});
+

--- a/tests/spec/spec-validation-primitives.test.ts
+++ b/tests/spec/spec-validation-primitives.test.ts
@@ -20,7 +20,7 @@ function makePrdArtifact(
     kind: "prd",
     metadata: createInitialArtifactMetadata({
       artifactId: "prd.main",
-      generator: "skill.generatePRD",
+      generator: "operation.generatePRD",
       sourceRefs: [{ artifact_id: "idea_brief", artifact_version: "v1" }],
       content: JSON.stringify(sections)
     }),
@@ -36,7 +36,7 @@ function makeSpecArtifact(
     kind: "spec",
     metadata: createInitialArtifactMetadata({
       artifactId: "spec.main",
-      generator: "skill.generateSpecPack",
+      generator: "operation.generateSpecPack",
       sourceRefs: [{ artifact_id: "prd.main", artifact_version: "v1" }],
       content: JSON.stringify(sections)
     }),
@@ -105,7 +105,7 @@ describe("reference and version validation", () => {
   });
 
   it("uses ownership registry and returns invalid_reference for unknown artifact kinds", () => {
-    expect(ARTIFACT_OWNERSHIP_REGISTRY.prd.owner_skill).toBe("skill.generatePRD");
+    expect(ARTIFACT_OWNERSHIP_REGISTRY.prd.owner_operation).toBe("operation.generatePRD");
 
     const issues = validateArtifactReferences({
       artifactId: "spec.main",
@@ -121,4 +121,3 @@ describe("reference and version validation", () => {
     ]);
   });
 });
-


### PR DESCRIPTION
## Summary
- implement `operation.generateSpecPack` with deterministic multi-artifact generation (`SPEC.md`, schema, acceptance, decisions, `dag.yaml`, index)
- add tests for spec-pack failure/success paths and versioning behavior
- standardize internal deterministic runtime terminology from `skills` to `operations` in core contracts/code/tests
- add architecture and contribution docs clarifying internal operations vs external skills

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

Closes #13
