### PR TITLE
feat: implement operation.validateSpecPack

### DIFF
--- a/src/core/operations/validateSpecPack.ts
+++ b/src/core/operations/validateSpecPack.ts
@@ -1,0 +1,261 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ArtifactMetadata, ArtifactSourceRef, ArtifactVersion } from "../artifacts/types.js";
+import {
+  createInitialArtifactMetadata,
+  createNextArtifactMetadata
+} from "../artifacts/versioning.js";
+import type { OperationContract } from "../contracts/operation.js";
+import type {
+  SpecArtifactContract,
+  ValidationIssue,
+  ValidationReportArtifactContract
+} from "../spec/contracts.js";
+import {
+  validateArtifactReferences,
+  validateRequiredSections
+} from "../spec/validation.js";
+
+const VALIDATION_REPORT_FILENAME = "validation_report.json";
+
+type ArtifactVersionIndex = Record<string, ArtifactVersion>;
+
+export type ValidateSpecPackErrorCode = "insufficient_spec" | "artifact_write_failed";
+
+export class ValidateSpecPackError extends Error {
+  readonly code: ValidateSpecPackErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: ValidateSpecPackErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "ValidateSpecPackError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface ValidateSpecPackInput {
+  spec_artifact?: SpecArtifactContract;
+  artifact_version_index?: ArtifactVersionIndex;
+  artifact_dir?: string;
+  created_timestamp?: Date;
+}
+
+export interface ValidateSpecPackResult {
+  validation_report: ValidationReportArtifactContract;
+  validation_issues: ValidationIssue[];
+}
+
+export const VALIDATE_SPEC_PACK_OPERATION_CONTRACT: OperationContract<
+  ValidateSpecPackInput,
+  ValidateSpecPackResult
+> = {
+  name: "operation.validateSpecPack",
+  version: "v1",
+  purpose: "Validate SPEC artifacts deterministically and publish a versioned validation report.",
+  inputs_schema: {} as ValidateSpecPackInput,
+  outputs_schema: {} as ValidateSpecPackResult,
+  side_effects: ["writes spec/validation_report.json artifact when artifact_dir is provided"],
+  invariants: [
+    "Validation is deterministic for equivalent spec input and version index.",
+    "Validation report artifacts carry immutable versioned metadata.",
+    "Report issues include explicit validation issue codes."
+  ],
+  idempotency_expectations: [
+    "Issue ordering is stable: required-section checks run before reference/version checks."
+  ],
+  failure_modes: ["insufficient_spec", "artifact_write_failed"],
+  observability_fields: [
+    "spec_artifact_id",
+    "spec_artifact_version",
+    "validation_report_version",
+    "validation_issue_count",
+    "passed"
+  ]
+};
+
+export async function runValidateSpecPack(
+  input: ValidateSpecPackInput
+): Promise<ValidateSpecPackResult> {
+  const specArtifact = ensureSpecArtifact(input.spec_artifact);
+
+  const requiredSectionIssues = validateRequiredSections(specArtifact);
+  const referenceIssues = validateArtifactReferences({
+    artifactId: specArtifact.metadata.artifact_id,
+    sourceRefs: specArtifact.source_refs,
+    artifactVersionIndex: input.artifact_version_index ?? {}
+  });
+
+  const validationIssues = [...requiredSectionIssues, ...referenceIssues];
+
+  const sourceRefs = buildValidationSourceRefs(specArtifact);
+  const reportContent = JSON.stringify(
+    {
+      target_artifact_id: specArtifact.metadata.artifact_id,
+      passed: validationIssues.length === 0,
+      issues: validationIssues
+    },
+    null,
+    2
+  );
+
+  const previousVersion = await readExistingValidationReportVersion(input.artifact_dir);
+
+  const metadata = createValidationMetadata({
+    source_refs: sourceRefs,
+    content: reportContent,
+    ...(previousVersion ? { previous_version: previousVersion } : {}),
+    ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+  });
+
+  const validationReport: ValidationReportArtifactContract = {
+    kind: "validation_report",
+    metadata,
+    target_artifact_id: specArtifact.metadata.artifact_id,
+    passed: validationIssues.length === 0,
+    issues: validationIssues
+  };
+
+  if (input.artifact_dir) {
+    await writeValidationReportArtifact(input.artifact_dir, validationReport);
+  }
+
+  return {
+    validation_report: validationReport,
+    validation_issues: validationIssues
+  };
+}
+
+function ensureSpecArtifact(artifact?: SpecArtifactContract): SpecArtifactContract {
+  if (!artifact || artifact.kind !== "spec") {
+    throw new ValidateSpecPackError("insufficient_spec", "Missing or invalid spec artifact.");
+  }
+
+  if (!artifact.metadata.artifact_id.startsWith("spec.")) {
+    throw new ValidateSpecPackError(
+      "insufficient_spec",
+      "spec artifact metadata.artifact_id must start with spec."
+    );
+  }
+
+  return artifact;
+}
+
+function buildValidationSourceRefs(specArtifact: SpecArtifactContract): ArtifactSourceRef[] {
+  const refs: ArtifactSourceRef[] = [
+    {
+      artifact_id: specArtifact.metadata.artifact_id,
+      artifact_version: specArtifact.metadata.artifact_version
+    },
+    ...specArtifact.source_refs
+  ];
+
+  const seen = new Set<string>();
+  const deduped: ArtifactSourceRef[] = [];
+
+  for (const ref of refs) {
+    const key = `${ref.artifact_id}@${ref.artifact_version}`;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push(ref);
+  }
+
+  return deduped;
+}
+
+interface CreateValidationMetadataInput {
+  previous_version?: ArtifactVersion;
+  source_refs: ArtifactSourceRef[];
+  content: string;
+  created_timestamp?: Date;
+}
+
+function createValidationMetadata(input: CreateValidationMetadataInput): ArtifactMetadata {
+  if (!input.previous_version) {
+    return createInitialArtifactMetadata({
+      artifactId: "validation_report.spec",
+      generator: "operation.validateSpecPack",
+      sourceRefs: input.source_refs,
+      content: input.content,
+      ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
+    });
+  }
+
+  return createNextArtifactMetadata({
+    previous: {
+      artifact_id: "validation_report.spec",
+      artifact_version: input.previous_version,
+      created_timestamp: "1970-01-01T00:00:00.000Z",
+      generator: "operation.validateSpecPack",
+      source_refs: input.source_refs,
+      checksum: "0".repeat(64)
+    },
+    generator: "operation.validateSpecPack",
+    sourceRefs: input.source_refs,
+    content: input.content,
+    ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
+  });
+}
+
+async function readExistingValidationReportVersion(
+  artifactDir?: string
+): Promise<ArtifactVersion | undefined> {
+  if (!artifactDir) {
+    return undefined;
+  }
+
+  try {
+    const raw = await readFile(join(artifactDir, "spec", VALIDATION_REPORT_FILENAME), "utf8");
+    const parsed = JSON.parse(raw) as Partial<ValidationReportArtifactContract>;
+    const version = parsed.metadata?.artifact_version;
+
+    if (typeof version === "string" && /^v\d+$/.test(version)) {
+      return version as ArtifactVersion;
+    }
+
+    throw new ValidateSpecPackError(
+      "artifact_write_failed",
+      "Existing validation_report has invalid metadata.artifact_version."
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+
+    if (error instanceof ValidateSpecPackError) {
+      throw error;
+    }
+
+    throw new ValidateSpecPackError(
+      "artifact_write_failed",
+      "Failed to read existing validation report metadata.",
+      error
+    );
+  }
+}
+
+async function writeValidationReportArtifact(
+  artifactDir: string,
+  validationReport: ValidationReportArtifactContract
+): Promise<void> {
+  const specDir = join(artifactDir, "spec");
+
+  try {
+    await mkdir(specDir, { recursive: true });
+    await writeFile(
+      join(specDir, VALIDATION_REPORT_FILENAME),
+      JSON.stringify(validationReport, null, 2),
+      "utf8"
+    );
+  } catch (error) {
+    throw new ValidateSpecPackError(
+      "artifact_write_failed",
+      "Failed writing validation report artifact.",
+      error
+    );
+  }
+}

--- a/tests/spec/validate-spec-pack.test.ts
+++ b/tests/spec/validate-spec-pack.test.ts
@@ -1,0 +1,171 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ValidateSpecPackError,
+  runValidateSpecPack
+} from "../../src/core/operations/validateSpecPack.js";
+import {
+  SPEC_REQUIRED_SECTIONS,
+  type SpecArtifactContract
+} from "../../src/core/spec/contracts.js";
+
+function buildSpecArtifact(
+  overrides?: Partial<SpecArtifactContract>
+): SpecArtifactContract {
+  const sections = {} as SpecArtifactContract["sections"];
+  for (const sectionId of SPEC_REQUIRED_SECTIONS) {
+    sections[sectionId] = `content for ${sectionId}`;
+  }
+
+  return {
+    kind: "spec",
+    metadata: {
+      artifact_id: "spec.main",
+      artifact_version: "v1",
+      created_timestamp: "2026-03-12T10:00:00.000Z",
+      generator: "operation.generateSpecPack",
+      source_refs: [{ artifact_id: "prd.main", artifact_version: "v3" }],
+      checksum: "c".repeat(64)
+    },
+    source_refs: [{ artifact_id: "prd.main", artifact_version: "v3" }],
+    sections,
+    ...overrides
+  };
+}
+
+describe("validateSpecPack failure paths", () => {
+  it("fails with typed error when spec artifact is missing", async () => {
+    await expect(
+      runValidateSpecPack({
+        artifact_version_index: { "prd.main": "v3" }
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<ValidateSpecPackError>>({
+        code: "insufficient_spec"
+      })
+    );
+  });
+});
+
+describe("validateSpecPack report generation", () => {
+  it("emits a passing validation_report artifact when required sections and references are valid", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-validate-spec-"));
+
+    const result = await runValidateSpecPack({
+      spec_artifact: buildSpecArtifact(),
+      artifact_version_index: { "prd.main": "v3" },
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-12T11:00:00.000Z")
+    });
+
+    expect(result.validation_report.kind).toBe("validation_report");
+    expect(result.validation_report.target_artifact_id).toBe("spec.main");
+    expect(result.validation_report.passed).toBe(true);
+    expect(result.validation_issues).toEqual([]);
+
+    expect(result.validation_report.metadata.artifact_id).toBe("validation_report.spec");
+    expect(result.validation_report.metadata.artifact_version).toBe("v1");
+    expect(result.validation_report.metadata.generator).toBe("operation.validateSpecPack");
+
+    const written = JSON.parse(
+      await readFile(join(artifactDir, "spec", "validation_report.json"), "utf8")
+    );
+    expect(written.metadata.artifact_id).toBe("validation_report.spec");
+    expect(written.passed).toBe(true);
+  });
+
+  it("emits missing_required_section when a required SPEC section is blank", async () => {
+    const spec = buildSpecArtifact({
+      sections: {
+        ...buildSpecArtifact().sections,
+        work_graph: ""
+      }
+    });
+
+    const result = await runValidateSpecPack({
+      spec_artifact: spec,
+      artifact_version_index: { "prd.main": "v3" }
+    });
+
+    expect(result.validation_report.passed).toBe(false);
+    expect(result.validation_issues).toEqual([
+      expect.objectContaining({
+        code: "missing_required_section",
+        section_id: "work_graph",
+        artifact_id: "spec.main"
+      })
+    ]);
+  });
+
+  it("emits invalid_reference for unknown referenced artifact kinds", async () => {
+    const spec = buildSpecArtifact({
+      source_refs: [{ artifact_id: "mystery.main", artifact_version: "v1" }],
+      metadata: {
+        ...buildSpecArtifact().metadata,
+        source_refs: [{ artifact_id: "mystery.main", artifact_version: "v1" }]
+      }
+    });
+
+    const result = await runValidateSpecPack({
+      spec_artifact: spec,
+      artifact_version_index: { "mystery.main": "v1" }
+    });
+
+    expect(result.validation_report.passed).toBe(false);
+    expect(result.validation_issues).toEqual([
+      expect.objectContaining({
+        code: "invalid_reference",
+        referenced_artifact_id: "mystery.main",
+        artifact_id: "spec.main"
+      })
+    ]);
+  });
+
+  it("emits version_mismatch when source ref version differs from artifact version index", async () => {
+    const result = await runValidateSpecPack({
+      spec_artifact: buildSpecArtifact({
+        source_refs: [{ artifact_id: "prd.main", artifact_version: "v3" }],
+        metadata: {
+          ...buildSpecArtifact().metadata,
+          source_refs: [{ artifact_id: "prd.main", artifact_version: "v3" }]
+        }
+      }),
+      artifact_version_index: { "prd.main": "v4" }
+    });
+
+    expect(result.validation_report.passed).toBe(false);
+    expect(result.validation_issues).toEqual([
+      expect.objectContaining({
+        code: "version_mismatch",
+        referenced_artifact_id: "prd.main",
+        expected_version: "v4",
+        actual_version: "v3"
+      })
+    ]);
+  });
+
+  it("increments validation_report artifact version on subsequent runs", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-validate-spec-"));
+
+    await runValidateSpecPack({
+      spec_artifact: buildSpecArtifact(),
+      artifact_version_index: { "prd.main": "v3" },
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-12T11:00:00.000Z")
+    });
+
+    const second = await runValidateSpecPack({
+      spec_artifact: buildSpecArtifact(),
+      artifact_version_index: { "prd.main": "v3" },
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-12T11:05:00.000Z")
+    });
+
+    expect(second.validation_report.metadata.artifact_version).toBe("v2");
+    expect(second.validation_report.metadata.parent_version).toBe("v1");
+  });
+});


### PR DESCRIPTION
## Summary
- implement `operation.validateSpecPack` as a deterministic validation operation
- publish a versioned `validation_report` artifact with explicit issue codes and pass/fail status
- compose existing validation primitives for required-section and reference/version checks
- persist `spec/validation_report.json` when `artifact_dir` is provided
- add TDD coverage for typed failure path, required-section/reference/version issue detection, and report version increments

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

Closes #14
