### PR TITLE
feat: add deterministic artifact index service

### DIFF
--- a/src/core/artifacts/index.ts
+++ b/src/core/artifacts/index.ts
@@ -1,0 +1,243 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { ArtifactVersion } from "./types.js";
+
+export interface ArtifactIndexEntry {
+  artifact_id: string;
+  versions: ArtifactVersion[];
+  latest_version: ArtifactVersion;
+}
+
+export interface ArtifactIndex {
+  schema_version: "v1";
+  entries: ArtifactIndexEntry[];
+}
+
+export interface RegisterArtifactVersionInput {
+  artifact_id: string;
+  artifact_version: ArtifactVersion;
+}
+
+export interface ResolveArtifactVersionInput {
+  artifact_id: string;
+  requested_version?: ArtifactVersion;
+}
+
+export type ArtifactIndexErrorCode = "invalid_index" | "read_failed" | "write_failed";
+
+export class ArtifactIndexError extends Error {
+  readonly code: ArtifactIndexErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: ArtifactIndexErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "ArtifactIndexError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export function createArtifactIndex(): ArtifactIndex {
+  return {
+    schema_version: "v1",
+    entries: []
+  };
+}
+
+export function registerArtifactVersion(
+  index: ArtifactIndex,
+  input: RegisterArtifactVersionInput
+): ArtifactIndex {
+  if (input.artifact_id.trim().length === 0) {
+    throw new ArtifactIndexError("invalid_index", "artifact_id must be non-empty.");
+  }
+
+  ensureArtifactVersion(input.artifact_version);
+
+  const byArtifact = new Map<string, ArtifactVersion[]>();
+
+  for (const entry of normalizeArtifactIndex(index).entries) {
+    byArtifact.set(entry.artifact_id, [...entry.versions]);
+  }
+
+  const existing = byArtifact.get(input.artifact_id) ?? [];
+  if (!existing.includes(input.artifact_version)) {
+    existing.push(input.artifact_version);
+  }
+  byArtifact.set(input.artifact_id, sortArtifactVersions(existing));
+
+  return buildIndexFromMap(byArtifact);
+}
+
+export function resolveArtifactVersion(
+  index: ArtifactIndex,
+  input: ResolveArtifactVersionInput
+): ArtifactVersion | undefined {
+  const normalized = normalizeArtifactIndex(index);
+  const entry = normalized.entries.find((current) => current.artifact_id === input.artifact_id);
+
+  if (!entry) {
+    return undefined;
+  }
+
+  if (!input.requested_version) {
+    return entry.latest_version;
+  }
+
+  return entry.versions.includes(input.requested_version) ? input.requested_version : undefined;
+}
+
+export function buildArtifactVersionIndex(index: ArtifactIndex): Record<string, ArtifactVersion> {
+  const normalized = normalizeArtifactIndex(index);
+  const lookup: Record<string, ArtifactVersion> = {};
+
+  for (const entry of normalized.entries) {
+    lookup[entry.artifact_id] = entry.latest_version;
+  }
+
+  return lookup;
+}
+
+export async function readArtifactIndex(filePath: string): Promise<ArtifactIndex> {
+  try {
+    const raw = await readFile(filePath, "utf8");
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      throw new ArtifactIndexError("invalid_index", "Artifact index JSON is invalid.", error);
+    }
+
+    return normalizeArtifactIndex(parsed);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return createArtifactIndex();
+    }
+
+    if (error instanceof ArtifactIndexError) {
+      throw error;
+    }
+
+    throw new ArtifactIndexError("read_failed", "Failed to read artifact index file.", error);
+  }
+}
+
+export async function writeArtifactIndex(
+  filePath: string,
+  index: ArtifactIndex
+): Promise<void> {
+  const normalized = normalizeArtifactIndex(index);
+
+  try {
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
+  } catch (error) {
+    throw new ArtifactIndexError("write_failed", "Failed to write artifact index file.", error);
+  }
+}
+
+function normalizeArtifactIndex(index: unknown): ArtifactIndex {
+  if (!isRecord(index)) {
+    throw new ArtifactIndexError("invalid_index", "Artifact index must be an object.");
+  }
+
+  if (index.schema_version !== "v1") {
+    throw new ArtifactIndexError("invalid_index", "Artifact index schema_version must be v1.");
+  }
+
+  if (!Array.isArray(index.entries)) {
+    throw new ArtifactIndexError("invalid_index", "Artifact index entries must be an array.");
+  }
+
+  const byArtifact = new Map<string, ArtifactVersion[]>();
+
+  for (const rawEntry of index.entries) {
+    if (!isRecord(rawEntry)) {
+      throw new ArtifactIndexError("invalid_index", "Artifact index entry must be an object.");
+    }
+
+    if (typeof rawEntry.artifact_id !== "string" || rawEntry.artifact_id.trim().length === 0) {
+      throw new ArtifactIndexError(
+        "invalid_index",
+        "Artifact index entry artifact_id must be a non-empty string."
+      );
+    }
+
+    if (!Array.isArray(rawEntry.versions) || rawEntry.versions.length === 0) {
+      throw new ArtifactIndexError(
+        "invalid_index",
+        `Artifact index entry ${rawEntry.artifact_id} must include non-empty versions.`
+      );
+    }
+
+    const versions = rawEntry.versions.map((version) => ensureArtifactVersion(version));
+    const canonicalVersions = sortArtifactVersions(versions);
+
+    if (typeof rawEntry.latest_version !== "string") {
+      throw new ArtifactIndexError(
+        "invalid_index",
+        `Artifact index entry ${rawEntry.artifact_id} latest_version must be a string.`
+      );
+    }
+
+    const latest = ensureArtifactVersion(rawEntry.latest_version);
+    const expectedLatest = canonicalVersions[canonicalVersions.length - 1];
+    if (latest !== expectedLatest) {
+      throw new ArtifactIndexError(
+        "invalid_index",
+        `Artifact index entry ${rawEntry.artifact_id} latest_version does not match versions.`
+      );
+    }
+
+    byArtifact.set(rawEntry.artifact_id, canonicalVersions);
+  }
+
+  return buildIndexFromMap(byArtifact);
+}
+
+function buildIndexFromMap(byArtifact: Map<string, ArtifactVersion[]>): ArtifactIndex {
+  const entries: ArtifactIndexEntry[] = [...byArtifact.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([artifactId, versions]) => {
+      const sorted = sortArtifactVersions(versions);
+      return {
+        artifact_id: artifactId,
+        versions: sorted,
+        latest_version: sorted[sorted.length - 1]!
+      };
+    });
+
+  return {
+    schema_version: "v1",
+    entries
+  };
+}
+
+function ensureArtifactVersion(version: unknown): ArtifactVersion {
+  if (typeof version !== "string" || !/^v\d+$/.test(version)) {
+    throw new ArtifactIndexError("invalid_index", `Invalid artifact version: ${String(version)}`);
+  }
+
+  return version as ArtifactVersion;
+}
+
+function sortArtifactVersions(versions: ArtifactVersion[]): ArtifactVersion[] {
+  return [...new Set(versions)].sort((left, right) => {
+    return parseArtifactVersion(left) - parseArtifactVersion(right);
+  });
+}
+
+function parseArtifactVersion(version: ArtifactVersion): number {
+  const numeric = Number.parseInt(version.slice(1), 10);
+  if (Number.isNaN(numeric)) {
+    throw new ArtifactIndexError("invalid_index", `Invalid artifact version: ${version}`);
+  }
+
+  return numeric;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/tests/core/artifact-index.test.ts
+++ b/tests/core/artifact-index.test.ts
@@ -1,0 +1,166 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ArtifactIndexError,
+  buildArtifactVersionIndex,
+  createArtifactIndex,
+  readArtifactIndex,
+  registerArtifactVersion,
+  resolveArtifactVersion,
+  writeArtifactIndex
+} from "../../src/core/artifacts/index.js";
+
+describe("artifact index deterministic registration", () => {
+  it("maintains deterministic ordering of entries and versions", () => {
+    const base = createArtifactIndex();
+
+    const withVersions = registerArtifactVersion(
+      registerArtifactVersion(
+        registerArtifactVersion(base, {
+          artifact_id: "prd.main",
+          artifact_version: "v2"
+        }),
+        {
+          artifact_id: "idea_brief",
+          artifact_version: "v1"
+        }
+      ),
+      {
+        artifact_id: "prd.main",
+        artifact_version: "v1"
+      }
+    );
+
+    expect(withVersions.entries).toEqual([
+      {
+        artifact_id: "idea_brief",
+        versions: ["v1"],
+        latest_version: "v1"
+      },
+      {
+        artifact_id: "prd.main",
+        versions: ["v1", "v2"],
+        latest_version: "v2"
+      }
+    ]);
+  });
+
+  it("deduplicates existing versions", () => {
+    const first = registerArtifactVersion(createArtifactIndex(), {
+      artifact_id: "spec.main",
+      artifact_version: "v1"
+    });
+
+    const second = registerArtifactVersion(first, {
+      artifact_id: "spec.main",
+      artifact_version: "v1"
+    });
+
+    expect(second.entries).toEqual([
+      {
+        artifact_id: "spec.main",
+        versions: ["v1"],
+        latest_version: "v1"
+      }
+    ]);
+  });
+});
+
+describe("artifact index lookup resolution", () => {
+  it("resolves latest by default and explicit versions when requested", () => {
+    const index = registerArtifactVersion(
+      registerArtifactVersion(createArtifactIndex(), {
+        artifact_id: "prd.main",
+        artifact_version: "v1"
+      }),
+      {
+        artifact_id: "prd.main",
+        artifact_version: "v3"
+      }
+    );
+
+    expect(resolveArtifactVersion(index, { artifact_id: "prd.main" })).toBe("v3");
+    expect(resolveArtifactVersion(index, { artifact_id: "prd.main", requested_version: "v1" })).toBe(
+      "v1"
+    );
+    expect(resolveArtifactVersion(index, { artifact_id: "prd.main", requested_version: "v2" })).toBe(
+      undefined
+    );
+    expect(resolveArtifactVersion(index, { artifact_id: "unknown.main" })).toBe(undefined);
+  });
+
+  it("produces latest-version lookup map for downstream validators", () => {
+    const index = registerArtifactVersion(
+      registerArtifactVersion(createArtifactIndex(), {
+        artifact_id: "idea_brief",
+        artifact_version: "v2"
+      }),
+      {
+        artifact_id: "prd.main",
+        artifact_version: "v4"
+      }
+    );
+
+    expect(buildArtifactVersionIndex(index)).toEqual({
+      idea_brief: "v2",
+      "prd.main": "v4"
+    });
+  });
+});
+
+describe("artifact index read/write", () => {
+  it("writes and reads a canonical deterministic index file", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "specforge-artifact-index-"));
+    const filePath = join(tmp, "artifact-index.json");
+
+    const index = registerArtifactVersion(
+      registerArtifactVersion(createArtifactIndex(), {
+        artifact_id: "spec.main",
+        artifact_version: "v2"
+      }),
+      {
+        artifact_id: "spec.main",
+        artifact_version: "v1"
+      }
+    );
+
+    await writeArtifactIndex(filePath, index);
+
+    const raw = await readFile(filePath, "utf8");
+    expect(raw.endsWith("\n")).toBe(true);
+
+    const parsed = await readArtifactIndex(filePath);
+    expect(parsed).toEqual({
+      schema_version: "v1",
+      entries: [
+        {
+          artifact_id: "spec.main",
+          versions: ["v1", "v2"],
+          latest_version: "v2"
+        }
+      ]
+    });
+  });
+
+  it("returns empty index for missing file path", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "specforge-artifact-index-"));
+    const filePath = join(tmp, "missing.json");
+
+    const result = await readArtifactIndex(filePath);
+    expect(result).toEqual(createArtifactIndex());
+  });
+
+  it("throws typed invalid_index error for malformed file content", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "specforge-artifact-index-"));
+    const filePath = join(tmp, "artifact-index.json");
+    await writeFile(filePath, "{\"schema_version\":\"v1\",\"entries\":\"bad\"}\n", "utf8");
+
+    await expect(readArtifactIndex(filePath)).rejects.toEqual(
+      expect.objectContaining<Partial<ArtifactIndexError>>({ code: "invalid_index" })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add core artifact index service with deterministic registration, canonical ordering, and immutable update semantics
- implement typed lookup semantics for latest and explicit artifact version resolution
- add deterministic read/write helpers for index persistence with canonical JSON output
- expose conversion helper for downstream validators/planners via latest-version lookup map
- include typed `ArtifactIndexError` codes for invalid index data and IO failures

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

Closes #15
