### PR TITLE
feat: implement operation.decomposeToWorkGraph

### DIFF
--- a/src/core/operations/decomposeToWorkGraph.ts
+++ b/src/core/operations/decomposeToWorkGraph.ts
@@ -1,0 +1,500 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ArtifactMetadata, ArtifactSourceRef, ArtifactVersion } from "../artifacts/types.js";
+import {
+  createInitialArtifactMetadata,
+  createNextArtifactMetadata,
+  deriveArtifactVersion
+} from "../artifacts/versioning.js";
+import type { ProjectMode } from "../contracts/domain.js";
+import type { OperationContract } from "../contracts/operation.js";
+import type { SpecArtifactContract } from "../spec/contracts.js";
+import type { PrdJsonArtifact } from "./generatePRD.js";
+
+const DAG_FILENAME = "dag.yaml";
+
+export type DecomposeToWorkGraphErrorCode =
+  | "invalid_mode"
+  | "insufficient_prd"
+  | "insufficient_spec"
+  | "insufficient_acceptance"
+  | "insufficient_contracts"
+  | "artifact_write_failed";
+
+export class DecomposeToWorkGraphError extends Error {
+  readonly code: DecomposeToWorkGraphErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: DecomposeToWorkGraphErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "DecomposeToWorkGraphError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface AcceptanceArtifactInput {
+  kind: "acceptance_markdown";
+  metadata: ArtifactMetadata;
+  source_refs: ArtifactSourceRef[];
+  path: string;
+  content: string;
+}
+
+export interface SchemaArtifactInput {
+  kind: "schema_json";
+  metadata: ArtifactMetadata;
+  source_refs: ArtifactSourceRef[];
+  path: string;
+  content: string;
+}
+
+export interface DecomposeToWorkGraphInput {
+  project_mode: ProjectMode;
+  prd_json?: PrdJsonArtifact;
+  spec_artifact?: SpecArtifactContract;
+  acceptance_artifact?: AcceptanceArtifactInput;
+  schema_artifact?: SchemaArtifactInput;
+  artifact_dir?: string;
+  created_timestamp?: Date;
+}
+
+export interface WorkGraphTask {
+  id: string;
+  title: string;
+  acceptance_refs: string[];
+  contract_refs: string[];
+  depends_on: string[];
+}
+
+export interface WorkGraphStory {
+  id: string;
+  title: string;
+  tasks: WorkGraphTask[];
+}
+
+export interface WorkGraphEpic {
+  id: string;
+  title: string;
+  stories: WorkGraphStory[];
+}
+
+export interface WorkGraph {
+  epics: WorkGraphEpic[];
+}
+
+export interface DagArtifact {
+  kind: "dag_yaml";
+  metadata: ArtifactMetadata;
+  source_refs: ArtifactSourceRef[];
+  path: "spec/dag.yaml";
+  content: string;
+}
+
+export interface DecomposeToWorkGraphResult {
+  dag_artifact: DagArtifact;
+  work_graph: WorkGraph;
+}
+
+export const DECOMPOSE_TO_WORK_GRAPH_OPERATION_CONTRACT: OperationContract<
+  DecomposeToWorkGraphInput,
+  DecomposeToWorkGraphResult
+> = {
+  name: "operation.decomposeToWorkGraph",
+  version: "v1",
+  purpose: "Derive deterministic EPIC/STORY/TASK dag artifacts from PRD, SPEC, acceptance, and contract artifacts.",
+  inputs_schema: {} as DecomposeToWorkGraphInput,
+  outputs_schema: {} as DecomposeToWorkGraphResult,
+  side_effects: ["writes spec/dag.yaml"],
+  invariants: [
+    "DAG tasks reference acceptance criteria and contracts.",
+    "Graph decomposition is deterministic for equivalent input artifacts.",
+    "Published DAG artifact metadata is versioned and immutable per run."
+  ],
+  idempotency_expectations: [
+    "Equivalent inputs produce stable task ordering and dependency structure."
+  ],
+  failure_modes: [
+    "invalid_mode",
+    "insufficient_prd",
+    "insufficient_spec",
+    "insufficient_acceptance",
+    "insufficient_contracts",
+    "artifact_write_failed"
+  ],
+  observability_fields: [
+    "project_mode",
+    "prd_version",
+    "spec_version",
+    "dag_version",
+    "task_count"
+  ]
+};
+
+export async function runDecomposeToWorkGraph(
+  input: DecomposeToWorkGraphInput
+): Promise<DecomposeToWorkGraphResult> {
+  if (input.project_mode !== "existing-repo") {
+    throw new DecomposeToWorkGraphError(
+      "invalid_mode",
+      "decomposeToWorkGraph currently supports project_mode=existing-repo."
+    );
+  }
+
+  const prdJson = ensurePrdJson(input.prd_json);
+  const specArtifact = ensureSpecArtifact(input.spec_artifact);
+  const acceptanceArtifact = ensureAcceptanceArtifact(input.acceptance_artifact);
+  const schemaArtifact = ensureSchemaArtifact(input.schema_artifact);
+
+  if (prdJson.project_mode !== input.project_mode) {
+    throw new DecomposeToWorkGraphError(
+      "invalid_mode",
+      "prd_json project_mode does not match requested mode."
+    );
+  }
+
+  const acceptanceCriteria = extractAcceptanceCriteria(acceptanceArtifact.content);
+  const contractRefs = buildContractRefs(schemaArtifact.path);
+  const graph = buildWorkGraph({
+    prd_json: prdJson,
+    spec_artifact: specArtifact,
+    acceptance_criteria: acceptanceCriteria,
+    contract_refs: contractRefs
+  });
+
+  const sourceRefs = buildSourceRefs([
+    prdJson.metadata,
+    specArtifact.metadata,
+    acceptanceArtifact.metadata,
+    schemaArtifact.metadata
+  ]);
+
+  const previousVersion = await readExistingDagVersion(input.artifact_dir);
+  const dagVersion = deriveArtifactVersion(previousVersion);
+  const dagContent = renderDagYaml({
+    version: dagVersion,
+    graph
+  });
+
+  const metadata = createDagMetadata({
+    source_refs: sourceRefs,
+    content: dagContent,
+    ...(previousVersion ? { previous_version: previousVersion } : {}),
+    ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+  });
+
+  const dagArtifact: DagArtifact = {
+    kind: "dag_yaml",
+    metadata,
+    source_refs: sourceRefs,
+    path: "spec/dag.yaml",
+    content: dagContent
+  };
+
+  if (input.artifact_dir) {
+    await writeDagArtifact(input.artifact_dir, dagArtifact.content);
+  }
+
+  return {
+    dag_artifact: dagArtifact,
+    work_graph: graph
+  };
+}
+
+function ensurePrdJson(artifact?: PrdJsonArtifact): PrdJsonArtifact {
+  if (!artifact || artifact.kind !== "prd_json") {
+    throw new DecomposeToWorkGraphError("insufficient_prd", "Missing or invalid prd_json artifact.");
+  }
+
+  if (artifact.metadata.artifact_id !== "prd.json") {
+    throw new DecomposeToWorkGraphError("insufficient_prd", "prd_json artifact_id must be prd.json.");
+  }
+
+  return artifact;
+}
+
+function ensureSpecArtifact(artifact?: SpecArtifactContract): SpecArtifactContract {
+  if (!artifact || artifact.kind !== "spec") {
+    throw new DecomposeToWorkGraphError("insufficient_spec", "Missing or invalid spec artifact.");
+  }
+
+  if (!artifact.metadata.artifact_id.startsWith("spec.")) {
+    throw new DecomposeToWorkGraphError(
+      "insufficient_spec",
+      "spec artifact metadata.artifact_id must start with spec."
+    );
+  }
+
+  return artifact;
+}
+
+function ensureAcceptanceArtifact(artifact?: AcceptanceArtifactInput): AcceptanceArtifactInput {
+  if (!artifact || artifact.kind !== "acceptance_markdown") {
+    throw new DecomposeToWorkGraphError(
+      "insufficient_acceptance",
+      "Missing or invalid acceptance artifact."
+    );
+  }
+
+  if (artifact.path.trim().length === 0 || artifact.content.trim().length === 0) {
+    throw new DecomposeToWorkGraphError(
+      "insufficient_acceptance",
+      "acceptance artifact path/content must be non-empty."
+    );
+  }
+
+  return artifact;
+}
+
+function ensureSchemaArtifact(artifact?: SchemaArtifactInput): SchemaArtifactInput {
+  if (!artifact || artifact.kind !== "schema_json") {
+    throw new DecomposeToWorkGraphError(
+      "insufficient_contracts",
+      "Missing or invalid schema artifact."
+    );
+  }
+
+  if (artifact.path.trim().length === 0 || artifact.content.trim().length === 0) {
+    throw new DecomposeToWorkGraphError(
+      "insufficient_contracts",
+      "schema artifact path/content must be non-empty."
+    );
+  }
+
+  return artifact;
+}
+
+interface AcceptanceCriterion {
+  id: string;
+  text: string;
+}
+
+function extractAcceptanceCriteria(content: string): AcceptanceCriterion[] {
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+
+  const bulletItems = lines
+    .filter((line) => line.startsWith("- "))
+    .map((line) => line.slice(2).trim())
+    .filter((line) => line.length > 0);
+
+  const criteriaText = bulletItems.length > 0
+    ? bulletItems
+    : lines.map((line) => line.trim()).filter((line) => line.length > 0);
+
+  if (criteriaText.length === 0) {
+    return [{ id: "AC-1", text: "Satisfy acceptance criteria." }];
+  }
+
+  return criteriaText.map((text, index) => ({
+    id: `AC-${index + 1}`,
+    text
+  }));
+}
+
+function buildContractRefs(schemaPath: string): string[] {
+  return [...new Set([schemaPath.trim(), "spec.contracts"])]
+    .filter((value) => value.length > 0)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+interface BuildWorkGraphInput {
+  prd_json: PrdJsonArtifact;
+  spec_artifact: SpecArtifactContract;
+  acceptance_criteria: AcceptanceCriterion[];
+  contract_refs: string[];
+}
+
+function buildWorkGraph(input: BuildWorkGraphInput): WorkGraph {
+  const tasks: WorkGraphTask[] = input.acceptance_criteria.map((criterion, index) => {
+    const taskId = `TASK-${index + 1}`;
+    const dependsOn = index === 0 ? [] : [`TASK-${index}`];
+
+    return {
+      id: taskId,
+      title: `Satisfy ${criterion.id}: ${truncateText(criterion.text, 88)}`,
+      acceptance_refs: [criterion.id],
+      contract_refs: [...input.contract_refs],
+      depends_on: dependsOn
+    };
+  });
+
+  return {
+    epics: [
+      {
+        id: "EPIC-1",
+        title: truncateText(
+          input.spec_artifact.sections.summary ?? input.prd_json.sections.outcome,
+          96
+        ),
+        stories: [
+          {
+            id: "STORY-1",
+            title: truncateText(input.prd_json.sections.workflow, 96),
+            tasks
+          }
+        ]
+      }
+    ]
+  };
+}
+
+function truncateText(value: string | undefined, maxLength: number): string {
+  const normalized = (value ?? "").replace(/\s+/g, " ").trim();
+  if (normalized.length === 0) {
+    return "Untitled";
+  }
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+function buildSourceRefs(metadataList: ArtifactMetadata[]): ArtifactSourceRef[] {
+  const refs: ArtifactSourceRef[] = metadataList.map((metadata) => ({
+    artifact_id: metadata.artifact_id,
+    artifact_version: metadata.artifact_version
+  }));
+
+  const deduped = new Map<string, ArtifactSourceRef>();
+  for (const ref of refs) {
+    const key = `${ref.artifact_id}@${ref.artifact_version}`;
+    deduped.set(key, ref);
+  }
+
+  return [...deduped.values()].sort((left, right) => {
+    if (left.artifact_id !== right.artifact_id) {
+      return left.artifact_id.localeCompare(right.artifact_id);
+    }
+
+    return left.artifact_version.localeCompare(right.artifact_version);
+  });
+}
+
+interface RenderDagYamlInput {
+  version: ArtifactVersion;
+  graph: WorkGraph;
+}
+
+function renderDagYaml(input: RenderDagYamlInput): string {
+  const lines: string[] = [`version: ${input.version}`, "epics:"];
+
+  for (const epic of input.graph.epics) {
+    lines.push(`  - id: ${epic.id}`);
+    lines.push(`    title: ${toYamlString(epic.title)}`);
+    lines.push("    stories:");
+
+    for (const story of epic.stories) {
+      lines.push(`      - id: ${story.id}`);
+      lines.push(`        title: ${toYamlString(story.title)}`);
+      lines.push("        tasks:");
+
+      for (const task of story.tasks) {
+        lines.push(`          - id: ${task.id}`);
+        lines.push(`            title: ${toYamlString(task.title)}`);
+        lines.push("            acceptance_refs:");
+        for (const acceptanceRef of task.acceptance_refs) {
+          lines.push(`              - ${acceptanceRef}`);
+        }
+        lines.push("            contract_refs:");
+        for (const contractRef of task.contract_refs) {
+          lines.push(`              - ${contractRef}`);
+        }
+        if (task.depends_on.length === 0) {
+          lines.push("            depends_on: []");
+        } else {
+          lines.push("            depends_on:");
+          for (const dependency of task.depends_on) {
+            lines.push(`              - ${dependency}`);
+          }
+        }
+      }
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function toYamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+interface CreateDagMetadataInput {
+  source_refs: ArtifactSourceRef[];
+  content: string;
+  previous_version?: ArtifactVersion;
+  created_timestamp?: Date;
+}
+
+function createDagMetadata(input: CreateDagMetadataInput): ArtifactMetadata {
+  if (!input.previous_version) {
+    return createInitialArtifactMetadata({
+      artifactId: "dag.yaml",
+      generator: "operation.decomposeToWorkGraph",
+      sourceRefs: input.source_refs,
+      content: input.content,
+      ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
+    });
+  }
+
+  return createNextArtifactMetadata({
+    previous: {
+      artifact_id: "dag.yaml",
+      artifact_version: input.previous_version,
+      created_timestamp: "1970-01-01T00:00:00.000Z",
+      generator: "operation.decomposeToWorkGraph",
+      source_refs: input.source_refs,
+      checksum: "0".repeat(64)
+    },
+    generator: "operation.decomposeToWorkGraph",
+    sourceRefs: input.source_refs,
+    content: input.content,
+    ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
+  });
+}
+
+async function readExistingDagVersion(artifactDir?: string): Promise<ArtifactVersion | undefined> {
+  if (!artifactDir) {
+    return undefined;
+  }
+
+  try {
+    const raw = await readFile(join(artifactDir, "spec", DAG_FILENAME), "utf8");
+    const match = /^version:\s*(v\d+)\s*$/m.exec(raw);
+    if (!match || !match[1]) {
+      return undefined;
+    }
+
+    return match[1] as ArtifactVersion;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+
+    throw new DecomposeToWorkGraphError(
+      "artifact_write_failed",
+      "Failed to inspect existing dag.yaml artifact.",
+      error
+    );
+  }
+}
+
+async function writeDagArtifact(artifactDir: string, dagContent: string): Promise<void> {
+  const specDir = join(artifactDir, "spec");
+
+  try {
+    await mkdir(specDir, { recursive: true });
+    await writeFile(join(specDir, DAG_FILENAME), dagContent, "utf8");
+  } catch (error) {
+    throw new DecomposeToWorkGraphError(
+      "artifact_write_failed",
+      "Failed writing dag.yaml artifact.",
+      error
+    );
+  }
+}

--- a/tests/planning/decompose-work-graph.test.ts
+++ b/tests/planning/decompose-work-graph.test.ts
@@ -1,0 +1,200 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DecomposeToWorkGraphError,
+  runDecomposeToWorkGraph
+} from "../../src/core/operations/decomposeToWorkGraph.js";
+import type { PrdJsonArtifact } from "../../src/core/operations/generatePRD.js";
+import { PRD_REQUIRED_SECTIONS, SPEC_REQUIRED_SECTIONS, type SpecArtifactContract } from "../../src/core/spec/contracts.js";
+
+function buildPrdJson(overrides?: Partial<PrdJsonArtifact>): PrdJsonArtifact {
+  const sections = {} as Record<(typeof PRD_REQUIRED_SECTIONS)[number], string>;
+  for (const sectionId of PRD_REQUIRED_SECTIONS) {
+    sections[sectionId] = `PRD section for ${sectionId}`;
+  }
+
+  return {
+    kind: "prd_json",
+    metadata: {
+      artifact_id: "prd.json",
+      artifact_version: "v3",
+      created_timestamp: "2026-03-12T20:00:00.000Z",
+      generator: "operation.generatePRD",
+      source_refs: [{ artifact_id: "idea_brief", artifact_version: "v2" }],
+      checksum: "a".repeat(64)
+    },
+    source_refs: [{ artifact_id: "idea_brief", artifact_version: "v2" }],
+    project_mode: "existing-repo",
+    sections,
+    unresolved_assumptions: [],
+    ...overrides
+  };
+}
+
+function buildSpecArtifact(overrides?: Partial<SpecArtifactContract>): SpecArtifactContract {
+  const sections = {} as Record<(typeof SPEC_REQUIRED_SECTIONS)[number], string>;
+  for (const sectionId of SPEC_REQUIRED_SECTIONS) {
+    sections[sectionId] = `SPEC section for ${sectionId}`;
+  }
+
+  return {
+    kind: "spec",
+    metadata: {
+      artifact_id: "spec.main",
+      artifact_version: "v2",
+      created_timestamp: "2026-03-12T20:10:00.000Z",
+      generator: "operation.generateSpecPack",
+      source_refs: [{ artifact_id: "prd.json", artifact_version: "v3" }],
+      checksum: "b".repeat(64)
+    },
+    source_refs: [{ artifact_id: "prd.json", artifact_version: "v3" }],
+    sections,
+    ...overrides
+  };
+}
+
+function buildAcceptanceArtifact() {
+  return {
+    kind: "acceptance_markdown" as const,
+    metadata: {
+      artifact_id: "acceptance.core",
+      artifact_version: "v2" as const,
+      created_timestamp: "2026-03-12T20:11:00.000Z",
+      generator: "operation.generateSpecPack",
+      source_refs: [{ artifact_id: "prd.json", artifact_version: "v3" as const }],
+      checksum: "c".repeat(64)
+    },
+    source_refs: [{ artifact_id: "prd.json", artifact_version: "v3" as const }],
+    path: "acceptance/core.md",
+    content: [
+      "# Acceptance Criteria",
+      "",
+      "- system emits deterministic dag output",
+      "- tasks reference acceptance criteria and contracts"
+    ].join("\n")
+  };
+}
+
+function buildSchemaArtifact() {
+  return {
+    kind: "schema_json" as const,
+    metadata: {
+      artifact_id: "schema.core",
+      artifact_version: "v2" as const,
+      created_timestamp: "2026-03-12T20:11:30.000Z",
+      generator: "operation.generateSpecPack",
+      source_refs: [{ artifact_id: "prd.json", artifact_version: "v3" as const }],
+      checksum: "d".repeat(64)
+    },
+    source_refs: [{ artifact_id: "prd.json", artifact_version: "v3" as const }],
+    path: "schemas/core.schema.json",
+    content: JSON.stringify({ type: "object" }, null, 2)
+  };
+}
+
+describe("decomposeToWorkGraph failure paths", () => {
+  it("fails with typed error when spec artifact is missing", async () => {
+    await expect(
+      runDecomposeToWorkGraph({
+        project_mode: "existing-repo",
+        prd_json: buildPrdJson(),
+        acceptance_artifact: buildAcceptanceArtifact(),
+        schema_artifact: buildSchemaArtifact()
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<DecomposeToWorkGraphError>>({
+        code: "insufficient_spec"
+      })
+    );
+  });
+
+  it("fails with typed error when mode is invalid", async () => {
+    await expect(
+      runDecomposeToWorkGraph({
+        project_mode: "greenfield",
+        prd_json: buildPrdJson(),
+        spec_artifact: buildSpecArtifact(),
+        acceptance_artifact: buildAcceptanceArtifact(),
+        schema_artifact: buildSchemaArtifact()
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<DecomposeToWorkGraphError>>({
+        code: "invalid_mode"
+      })
+    );
+  });
+});
+
+describe("decomposeToWorkGraph success paths", () => {
+  it("emits dag.yaml tasks that reference acceptance criteria and contracts", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-decompose-"));
+
+    const result = await runDecomposeToWorkGraph({
+      project_mode: "existing-repo",
+      prd_json: buildPrdJson(),
+      spec_artifact: buildSpecArtifact({
+        sections: {
+          ...buildSpecArtifact().sections,
+          summary: "Ship deterministic decomposition",
+          contracts: "Use stable schema and contract checks"
+        }
+      }),
+      acceptance_artifact: buildAcceptanceArtifact(),
+      schema_artifact: buildSchemaArtifact(),
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-12T20:30:00.000Z")
+    });
+
+    expect(result.dag_artifact.metadata.artifact_id).toBe("dag.yaml");
+    expect(result.dag_artifact.metadata.artifact_version).toBe("v1");
+    expect(result.dag_artifact.metadata.generator).toBe("operation.decomposeToWorkGraph");
+
+    expect(result.work_graph.epics).toHaveLength(1);
+    const tasks = result.work_graph.epics[0]?.stories[0]?.tasks;
+    expect(tasks?.map((task) => task.id)).toEqual(["TASK-1", "TASK-2"]);
+    expect(tasks?.[0]?.acceptance_refs).toEqual(["AC-1"]);
+    expect(tasks?.[0]?.contract_refs).toEqual(["schemas/core.schema.json", "spec.contracts"]);
+    expect(tasks?.[1]?.depends_on).toEqual(["TASK-1"]);
+
+    const dagYaml = await readFile(join(artifactDir, "spec", "dag.yaml"), "utf8");
+    expect(dagYaml).toContain("version: v1");
+    expect(dagYaml).toContain("acceptance_refs:");
+    expect(dagYaml).toContain("contract_refs:");
+    expect(dagYaml).toContain("- AC-1");
+    expect(dagYaml).toContain("- schemas/core.schema.json");
+  });
+
+  it("increments dag artifact version on subsequent runs", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-decompose-"));
+
+    await runDecomposeToWorkGraph({
+      project_mode: "existing-repo",
+      prd_json: buildPrdJson(),
+      spec_artifact: buildSpecArtifact(),
+      acceptance_artifact: buildAcceptanceArtifact(),
+      schema_artifact: buildSchemaArtifact(),
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-12T20:40:00.000Z")
+    });
+
+    const second = await runDecomposeToWorkGraph({
+      project_mode: "existing-repo",
+      prd_json: buildPrdJson(),
+      spec_artifact: buildSpecArtifact(),
+      acceptance_artifact: buildAcceptanceArtifact(),
+      schema_artifact: buildSchemaArtifact(),
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-12T20:45:00.000Z")
+    });
+
+    expect(second.dag_artifact.metadata.artifact_version).toBe("v2");
+    expect(second.dag_artifact.metadata.parent_version).toBe("v1");
+
+    const dagYaml = await readFile(join(artifactDir, "spec", "dag.yaml"), "utf8");
+    expect(dagYaml).toContain("version: v2");
+  });
+});


### PR DESCRIPTION
## Summary
- implement `operation.decomposeToWorkGraph` as a deterministic DAG decomposition operation
- derive EPIC/STORY/TASK structure from PRD + SPEC + acceptance + schema artifacts
- ensure tasks explicitly reference acceptance criteria (`AC-*`) and contract references (`schemas/core.schema.json`, `spec.contracts`)
- emit versioned `dag.yaml` artifact at `spec/dag.yaml` with stable ordering and dependency chaining
- add typed failure modes for missing/invalid inputs and unsupported project mode
- add TDD coverage for failure paths, DAG reference correctness, and artifact version increment behavior

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

Closes #16
