### PR TITLE
feat: implement operation.devTDDTask

### DIFF
--- a/src/core/operations/devTDDTask.ts
+++ b/src/core/operations/devTDDTask.ts
@@ -1,0 +1,429 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ArtifactMetadata, ArtifactSourceRef, ArtifactVersion } from "../artifacts/types.js";
+import {
+  createInitialArtifactMetadata,
+  createNextArtifactMetadata
+} from "../artifacts/versioning.js";
+import type { ProjectMode } from "../contracts/domain.js";
+import type { OperationContract } from "../contracts/operation.js";
+import type { ContextPackArtifact } from "./buildContextPack.js";
+
+const TASK_RESULTS_DIR = join(".specforge", "task-results");
+const TDD_PHASE_ORDER = ["red", "green", "refactor"] as const;
+
+export type TddPhase = (typeof TDD_PHASE_ORDER)[number];
+export type TddPhaseStatus = "failed" | "passed";
+
+export type DevTddTaskErrorCode =
+  | "invalid_mode"
+  | "insufficient_context_pack"
+  | "invalid_tdd_sequence"
+  | "phase_contract_violation"
+  | "artifact_write_failed";
+
+export class DevTddTaskError extends Error {
+  readonly code: DevTddTaskErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: DevTddTaskErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "DevTddTaskError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface DevTddTaskPhaseInput {
+  phase: TddPhase;
+  status: TddPhaseStatus;
+  summary: string;
+  evidence: string[];
+  commands: string[];
+}
+
+export interface DevTddTaskInput {
+  project_mode: ProjectMode;
+  context_pack?: ContextPackArtifact;
+  phases: DevTddTaskPhaseInput[];
+  branch_ref?: string;
+  pr_ref?: string;
+  artifact_dir?: string;
+  created_timestamp?: Date;
+}
+
+export interface DevTddTaskPhaseRecord {
+  phase: TddPhase;
+  status: TddPhaseStatus;
+  summary: string;
+  evidence: string[];
+  commands: string[];
+}
+
+export interface TaskExecutionResultArtifact {
+  kind: "task_execution_result";
+  metadata: ArtifactMetadata;
+  project_mode: "existing-repo";
+  task_id: string;
+  context_pack_ref: ArtifactSourceRef;
+  phase_order: TddPhase[];
+  phases: DevTddTaskPhaseRecord[];
+  status: "completed";
+  branch_ref?: string;
+  pr_ref?: string;
+  summary_markdown: string;
+}
+
+export interface DevTddTaskResult {
+  task_execution_result: TaskExecutionResultArtifact;
+}
+
+export const DEV_TDD_TASK_OPERATION_CONTRACT: OperationContract<
+  DevTddTaskInput,
+  DevTddTaskResult
+> = {
+  name: "operation.devTDDTask",
+  version: "v1",
+  purpose: "Validate and publish a single-task RED/GREEN/REFACTOR execution result.",
+  inputs_schema: {} as DevTddTaskInput,
+  outputs_schema: {} as DevTddTaskResult,
+  side_effects: ["writes .specforge/task-results/<task_id>.json"],
+  invariants: [
+    "Execution phases always follow strict RED/GREEN/REFACTOR ordering.",
+    "Red must fail first, then green and refactor must preserve passing state.",
+    "Branch and PR references are recorded only when explicitly provided by upstream execution tooling."
+  ],
+  idempotency_expectations: [
+    "Equivalent context pack and phase transcript inputs produce stable execution-result artifacts."
+  ],
+  failure_modes: [
+    "invalid_mode",
+    "insufficient_context_pack",
+    "invalid_tdd_sequence",
+    "phase_contract_violation",
+    "artifact_write_failed"
+  ],
+  observability_fields: [
+    "task_id",
+    "context_pack_version",
+    "execution_result_version",
+    "phase_count",
+    "branch_ref"
+  ]
+};
+
+/**
+ * Publishes a bounded execution result for one atomic task.
+ *
+ * This slice does not run git operations or retry loops. It validates the recorded
+ * TDD transcript from upstream execution tooling and turns it into a versioned,
+ * provenance-aware artifact that later critic/repair logic can consume.
+ */
+export async function runDevTddTask(input: DevTddTaskInput): Promise<DevTddTaskResult> {
+  if (input.project_mode !== "existing-repo") {
+    throw new DevTddTaskError(
+      "invalid_mode",
+      "devTDDTask currently supports project_mode=existing-repo."
+    );
+  }
+
+  const contextPack = ensureContextPack(input.context_pack);
+  const phases = normalizePhaseInputs(input.phases);
+  ensurePhaseSequence(phases);
+  ensurePhaseContract(phases);
+
+  const contextPackRef: ArtifactSourceRef = {
+    artifact_id: contextPack.metadata.artifact_id,
+    artifact_version: contextPack.metadata.artifact_version
+  };
+
+  const artifactDir = input.artifact_dir;
+  const previousVersion = artifactDir
+    ? await readExistingTaskExecutionResultVersion({ artifact_dir: artifactDir, task_id: contextPack.task.id })
+    : undefined;
+  const summaryMarkdown = renderExecutionSummaryMarkdown({
+    task_id: contextPack.task.id,
+    task_title: contextPack.task.title,
+    phases,
+    ...(input.branch_ref ? { branch_ref: input.branch_ref } : {}),
+    ...(input.pr_ref ? { pr_ref: input.pr_ref } : {})
+  });
+
+  const taskExecutionResult: TaskExecutionResultArtifact = {
+    kind: "task_execution_result",
+    metadata: createTaskExecutionResultMetadata({
+      task_id: contextPack.task.id,
+      source_refs: [contextPackRef],
+      content: JSON.stringify({
+        task_id: contextPack.task.id,
+        context_pack_ref: contextPackRef,
+        phases,
+        branch_ref: input.branch_ref,
+        pr_ref: input.pr_ref,
+        summary_markdown: summaryMarkdown
+      }),
+      ...(previousVersion ? { previous_version: previousVersion } : {}),
+      ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+    }),
+    project_mode: "existing-repo",
+    task_id: contextPack.task.id,
+    context_pack_ref: contextPackRef,
+    phase_order: [...TDD_PHASE_ORDER],
+    phases,
+    status: "completed",
+    ...(input.branch_ref ? { branch_ref: input.branch_ref } : {}),
+    ...(input.pr_ref ? { pr_ref: input.pr_ref } : {}),
+    summary_markdown: summaryMarkdown
+  };
+
+  if (artifactDir) {
+    await writeTaskExecutionResultArtifact({
+      artifact_dir: artifactDir,
+      task_id: contextPack.task.id,
+      task_execution_result: taskExecutionResult
+    });
+  }
+
+  return {
+    task_execution_result: taskExecutionResult
+  };
+}
+
+function ensureContextPack(contextPack?: ContextPackArtifact): ContextPackArtifact {
+  if (!contextPack || contextPack.kind !== "context_pack") {
+    throw new DevTddTaskError(
+      "insufficient_context_pack",
+      "Missing or invalid context_pack artifact."
+    );
+  }
+
+  if (contextPack.task.id.trim().length === 0) {
+    throw new DevTddTaskError(
+      "insufficient_context_pack",
+      "context_pack task id must be non-empty."
+    );
+  }
+
+  return contextPack;
+}
+
+function normalizePhaseInputs(phases: DevTddTaskPhaseInput[]): DevTddTaskPhaseRecord[] {
+  return phases.map((phase) => {
+    const summary = phase.summary.trim();
+    const evidence = normalizeStringArray(phase.evidence);
+    const commands = normalizeStringArray(phase.commands);
+
+    if (summary.length === 0 || evidence.length === 0 || commands.length === 0) {
+      throw new DevTddTaskError(
+        "phase_contract_violation",
+        `Phase ${phase.phase} must include non-empty summary, evidence, and commands.`
+      );
+    }
+
+    return {
+      phase: phase.phase,
+      status: phase.status,
+      summary,
+      evidence,
+      commands
+    };
+  });
+}
+
+function ensurePhaseSequence(phases: DevTddTaskPhaseRecord[]): void {
+  if (phases.length !== TDD_PHASE_ORDER.length) {
+    throw new DevTddTaskError(
+      "invalid_tdd_sequence",
+      "devTDDTask requires exactly red, green, and refactor phases."
+    );
+  }
+
+  for (const [index, expectedPhase] of TDD_PHASE_ORDER.entries()) {
+    if (phases[index]?.phase !== expectedPhase) {
+      throw new DevTddTaskError(
+        "invalid_tdd_sequence",
+        `Expected phase order ${TDD_PHASE_ORDER.join(" -> ")}.`
+      );
+    }
+  }
+}
+
+function ensurePhaseContract(phases: DevTddTaskPhaseRecord[]): void {
+  const [redPhase, greenPhase, refactorPhase] = phases;
+
+  // The contract is intentionally strict so later retry logic can reason about
+  // exactly which phase failed without inferring intent from free-form logs.
+  if (redPhase?.status !== "failed") {
+    throw new DevTddTaskError(
+      "phase_contract_violation",
+      "Red phase must fail first to prove the test drove the change."
+    );
+  }
+
+  if (greenPhase?.status !== "passed") {
+    throw new DevTddTaskError(
+      "phase_contract_violation",
+      "Green phase must pass after the minimal implementation change."
+    );
+  }
+
+  if (refactorPhase?.status !== "passed") {
+    throw new DevTddTaskError(
+      "phase_contract_violation",
+      "Refactor phase must preserve a passing state."
+    );
+  }
+}
+
+function normalizeStringArray(values: string[]): string[] {
+  return values
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+interface RenderExecutionSummaryMarkdownInput {
+  task_id: string;
+  task_title: string;
+  phases: DevTddTaskPhaseRecord[];
+  branch_ref?: string;
+  pr_ref?: string;
+}
+
+function renderExecutionSummaryMarkdown(input: RenderExecutionSummaryMarkdownInput): string {
+  const lines: string[] = [
+    "# Task Execution Result",
+    "",
+    `Task ID: ${input.task_id}`,
+    `Task Title: ${input.task_title}`,
+    "",
+    "Status: completed"
+  ];
+
+  if (input.branch_ref) {
+    lines.push(`Branch Ref: ${input.branch_ref}`);
+  }
+
+  if (input.pr_ref) {
+    lines.push(`PR Ref: ${input.pr_ref}`);
+  }
+
+  lines.push("");
+
+  for (const phase of input.phases) {
+    lines.push(`## ${capitalizePhase(phase.phase)}`);
+    lines.push(`Status: ${phase.status}`);
+    lines.push(`Summary: ${phase.summary}`);
+    lines.push(`Evidence: ${phase.evidence.join(", ")}`);
+    lines.push(`Commands: ${phase.commands.join(" | ")}`);
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function capitalizePhase(phase: TddPhase): string {
+  return phase.charAt(0).toUpperCase() + phase.slice(1);
+}
+
+interface CreateTaskExecutionResultMetadataInput {
+  task_id: string;
+  source_refs: ArtifactSourceRef[];
+  content: string;
+  previous_version?: ArtifactVersion;
+  created_timestamp?: Date;
+}
+
+function createTaskExecutionResultMetadata(
+  input: CreateTaskExecutionResultMetadataInput
+): ArtifactMetadata {
+  const artifactId = buildTaskExecutionArtifactId(input.task_id);
+
+  if (!input.previous_version) {
+    return createInitialArtifactMetadata({
+      artifactId,
+      generator: "operation.devTDDTask",
+      sourceRefs: input.source_refs,
+      content: input.content,
+      ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
+    });
+  }
+
+  return createNextArtifactMetadata({
+    previous: {
+      artifact_id: artifactId,
+      artifact_version: input.previous_version,
+      created_timestamp: "1970-01-01T00:00:00.000Z",
+      generator: "operation.devTDDTask",
+      source_refs: input.source_refs,
+      checksum: "0".repeat(64)
+    },
+    generator: "operation.devTDDTask",
+    sourceRefs: input.source_refs,
+    content: input.content,
+    ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
+  });
+}
+
+async function readExistingTaskExecutionResultVersion(input: {
+  artifact_dir: string;
+  task_id: string;
+}): Promise<ArtifactVersion | undefined> {
+  try {
+    const raw = await readFile(
+      join(input.artifact_dir, TASK_RESULTS_DIR, `${input.task_id}.json`),
+      "utf8"
+    );
+    const parsed = JSON.parse(raw) as Partial<TaskExecutionResultArtifact>;
+    const version = parsed.metadata?.artifact_version;
+
+    if (typeof version === "string" && /^v\d+$/.test(version)) {
+      return version as ArtifactVersion;
+    }
+
+    throw new DevTddTaskError(
+      "artifact_write_failed",
+      `Existing task execution result for ${input.task_id} has invalid metadata.artifact_version.`
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+
+    if (error instanceof DevTddTaskError) {
+      throw error;
+    }
+
+    throw new DevTddTaskError(
+      "artifact_write_failed",
+      `Failed to inspect existing task execution result for ${input.task_id}.`,
+      error
+    );
+  }
+}
+
+async function writeTaskExecutionResultArtifact(input: {
+  artifact_dir: string;
+  task_id: string;
+  task_execution_result: TaskExecutionResultArtifact;
+}): Promise<void> {
+  try {
+    const outputDir = join(input.artifact_dir, TASK_RESULTS_DIR);
+    await mkdir(outputDir, { recursive: true });
+    await writeFile(
+      join(outputDir, `${input.task_id}.json`),
+      `${JSON.stringify(input.task_execution_result, null, 2)}\n`,
+      "utf8"
+    );
+  } catch (error) {
+    throw new DevTddTaskError(
+      "artifact_write_failed",
+      `Failed writing task execution result for ${input.task_id}.`,
+      error
+    );
+  }
+}
+
+function buildTaskExecutionArtifactId(taskId: string): `task_execution_result.${string}` {
+  return `task_execution_result.${taskId.toLowerCase()}`;
+}

--- a/src/core/spec/ownership.ts
+++ b/src/core/spec/ownership.ts
@@ -4,6 +4,7 @@ export const ARTIFACT_KINDS = [
   "spec",
   "architecture_summary",
   "delta_spec",
+  "task_execution_result",
   "proposal_summary",
   "proposal_draft",
   "context_pack",
@@ -38,6 +39,10 @@ export const ARTIFACT_OWNERSHIP_REGISTRY: Record<ArtifactKind, ArtifactOwnership
   delta_spec: {
     artifact_kind: "delta_spec",
     owner_operation: "operation.generateDeltaSpec"
+  },
+  task_execution_result: {
+    artifact_kind: "task_execution_result",
+    owner_operation: "operation.devTDDTask"
   },
   proposal_summary: {
     artifact_kind: "proposal_summary",
@@ -80,6 +85,10 @@ export function inferArtifactKindFromId(artifactId: string): ArtifactKind | unde
 
   if (artifactId === "delta_spec") {
     return "delta_spec";
+  }
+
+  if (artifactId.startsWith("task_execution_result.")) {
+    return "task_execution_result";
   }
 
   if (artifactId === "proposal_summary.md") {

--- a/tests/execution/dev-tdd-task.test.ts
+++ b/tests/execution/dev-tdd-task.test.ts
@@ -1,0 +1,253 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import type { ContextPackArtifact } from "../../src/core/operations/buildContextPack.js";
+import {
+  DevTddTaskError,
+  runDevTddTask
+} from "../../src/core/operations/devTDDTask.js";
+import { ARTIFACT_OWNERSHIP_REGISTRY, inferArtifactKindFromId } from "../../src/core/spec/ownership.js";
+
+function buildContextPack(overrides?: Partial<ContextPackArtifact>): ContextPackArtifact {
+  return {
+    kind: "context_pack",
+    metadata: {
+      artifact_id: "context_pack.task-1",
+      artifact_version: "v2",
+      created_timestamp: "2026-03-13T00:00:00.000Z",
+      generator: "operation.buildContextPack",
+      source_refs: [
+        { artifact_id: "prd.json", artifact_version: "v2" },
+        { artifact_id: "spec.main", artifact_version: "v1" }
+      ],
+      checksum: "a".repeat(64)
+    },
+    task: {
+      id: "TASK-1",
+      title: "Validate acceptance coverage",
+      acceptance_refs: ["AC-1"],
+      contract_refs: ["schemas/core.schema.json"],
+      depends_on: []
+    },
+    entries: [
+      {
+        kind: "task_definition",
+        source_ref: { artifact_id: "dag.yaml", artifact_version: "v1" },
+        locator: "TASK-1",
+        excerpt: "Task: Validate acceptance coverage"
+      },
+      {
+        kind: "acceptance_excerpt",
+        source_ref: { artifact_id: "acceptance.core", artifact_version: "v1" },
+        locator: "AC-1",
+        excerpt: "verify acceptance coverage"
+      }
+    ],
+    ...overrides
+  };
+}
+
+describe("devTDDTask failure paths", () => {
+  it("fails with a typed error when context_pack is missing", async () => {
+    await expect(
+      runDevTddTask({
+        project_mode: "existing-repo",
+        phases: []
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<DevTddTaskError>>({
+        code: "insufficient_context_pack"
+      })
+    );
+  });
+
+  it("fails when phases are not in strict red-green-refactor order", async () => {
+    await expect(
+      runDevTddTask({
+        project_mode: "existing-repo",
+        context_pack: buildContextPack(),
+        phases: [
+          {
+            phase: "green",
+            status: "passed",
+            summary: "Implementation added.",
+            evidence: ["src/task.ts"],
+            commands: ["pnpm test -- --run tests/task.test.ts"]
+          },
+          {
+            phase: "red",
+            status: "failed",
+            summary: "Test added and failing first.",
+            evidence: ["tests/task.test.ts"],
+            commands: ["pnpm test -- --run tests/task.test.ts"]
+          },
+          {
+            phase: "refactor",
+            status: "passed",
+            summary: "Cleanup preserved passing state.",
+            evidence: ["src/task.ts"],
+            commands: ["pnpm test -- --run tests/task.test.ts"]
+          }
+        ]
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<DevTddTaskError>>({
+        code: "invalid_tdd_sequence"
+      })
+    );
+  });
+
+  it("fails when phase outcomes violate the TDD contract", async () => {
+    await expect(
+      runDevTddTask({
+        project_mode: "existing-repo",
+        context_pack: buildContextPack(),
+        phases: [
+          {
+            phase: "red",
+            status: "passed",
+            summary: "Test unexpectedly passed.",
+            evidence: ["tests/task.test.ts"],
+            commands: ["pnpm test -- --run tests/task.test.ts"]
+          },
+          {
+            phase: "green",
+            status: "passed",
+            summary: "Implementation added.",
+            evidence: ["src/task.ts"],
+            commands: ["pnpm test -- --run tests/task.test.ts"]
+          },
+          {
+            phase: "refactor",
+            status: "passed",
+            summary: "Cleanup preserved passing state.",
+            evidence: ["src/task.ts"],
+            commands: ["pnpm test -- --run tests/task.test.ts"]
+          }
+        ]
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<DevTddTaskError>>({
+        code: "phase_contract_violation"
+      })
+    );
+  });
+});
+
+describe("devTDDTask success paths", () => {
+  it("registers task execution results to operation.devTDDTask", () => {
+    expect(ARTIFACT_OWNERSHIP_REGISTRY.task_execution_result.owner_operation).toBe(
+      "operation.devTDDTask"
+    );
+    expect(inferArtifactKindFromId("task_execution_result.task-1")).toBe("task_execution_result");
+  });
+
+  it("produces a versioned task execution result with structured phase output", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-dev-tdd-task-"));
+
+    const result = await runDevTddTask({
+      project_mode: "existing-repo",
+      context_pack: buildContextPack(),
+      branch_ref: "feat/task-1",
+      pr_ref: "https://github.com/iKwesi/SpecForge/pull/999",
+      phases: [
+        {
+          phase: "red",
+          status: "failed",
+          summary: "Added a failing acceptance-focused test.",
+          evidence: ["tests/task.test.ts"],
+          commands: ["pnpm test -- --run tests/task.test.ts"]
+        },
+        {
+          phase: "green",
+          status: "passed",
+          summary: "Implemented the minimal production change.",
+          evidence: ["src/task.ts", "tests/task.test.ts"],
+          commands: ["pnpm test -- --run tests/task.test.ts"]
+        },
+        {
+          phase: "refactor",
+          status: "passed",
+          summary: "Simplified the implementation and reran tests.",
+          evidence: ["src/task.ts"],
+          commands: ["pnpm test -- --run tests/task.test.ts", "pnpm typecheck"]
+        }
+      ],
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-13T13:00:00.000Z")
+    });
+
+    expect(result.task_execution_result.kind).toBe("task_execution_result");
+    expect(result.task_execution_result.metadata.artifact_id).toBe("task_execution_result.task-1");
+    expect(result.task_execution_result.metadata.artifact_version).toBe("v1");
+    expect(result.task_execution_result.metadata.generator).toBe("operation.devTDDTask");
+    expect(result.task_execution_result.status).toBe("completed");
+    expect(result.task_execution_result.phase_order).toEqual(["red", "green", "refactor"]);
+    expect(result.task_execution_result.branch_ref).toBe("feat/task-1");
+    expect(result.task_execution_result.pr_ref).toBe(
+      "https://github.com/iKwesi/SpecForge/pull/999"
+    );
+    expect(result.task_execution_result.context_pack_ref).toEqual({
+      artifact_id: "context_pack.task-1",
+      artifact_version: "v2"
+    });
+    expect(result.task_execution_result.summary_markdown).toContain("# Task Execution Result");
+    expect(result.task_execution_result.summary_markdown).toContain("## Red");
+    expect(result.task_execution_result.summary_markdown).toContain("## Refactor");
+
+    const written = JSON.parse(
+      await readFile(join(artifactDir, ".specforge", "task-results", "TASK-1.json"), "utf8")
+    );
+    expect(written.metadata.artifact_id).toBe("task_execution_result.task-1");
+    expect(written.task_id).toBe("TASK-1");
+  });
+
+  it("increments task execution result versions on subsequent runs", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-dev-tdd-task-version-"));
+
+    const input = {
+      project_mode: "existing-repo" as const,
+      context_pack: buildContextPack(),
+      phases: [
+        {
+          phase: "red" as const,
+          status: "failed" as const,
+          summary: "Added a failing acceptance-focused test.",
+          evidence: ["tests/task.test.ts"],
+          commands: ["pnpm test -- --run tests/task.test.ts"]
+        },
+        {
+          phase: "green" as const,
+          status: "passed" as const,
+          summary: "Implemented the minimal production change.",
+          evidence: ["src/task.ts", "tests/task.test.ts"],
+          commands: ["pnpm test -- --run tests/task.test.ts"]
+        },
+        {
+          phase: "refactor" as const,
+          status: "passed" as const,
+          summary: "Simplified the implementation and reran tests.",
+          evidence: ["src/task.ts"],
+          commands: ["pnpm test -- --run tests/task.test.ts", "pnpm typecheck"]
+        }
+      ],
+      artifact_dir: artifactDir
+    };
+
+    await runDevTddTask({
+      ...input,
+      created_timestamp: new Date("2026-03-13T13:10:00.000Z")
+    });
+
+    const second = await runDevTddTask({
+      ...input,
+      created_timestamp: new Date("2026-03-13T13:15:00.000Z")
+    });
+
+    expect(second.task_execution_result.metadata.artifact_version).toBe("v2");
+    expect(second.task_execution_result.metadata.parent_version).toBe("v1");
+  });
+});


### PR DESCRIPTION
## Summary
- add operation.devTDDTask as the deterministic single-task RED/GREEN/REFACTOR execution contract
- generate versioned task execution result artifacts from context packs and validated TDD transcripts
- register task execution result ownership and cover ordering, contract violations, and versioning with tests

## Testing
- pnpm test
- pnpm typecheck
- pnpm build

Closes #23