### PR TITLE
feat: implement git provider abstraction

### DIFF
--- a/src/core/git/provider.ts
+++ b/src/core/git/provider.ts
@@ -1,0 +1,411 @@
+import { execFile } from "node:child_process";
+import { lstat, realpath } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const GIT_PROVIDER_NAMES = ["native-git", "gitbutler"] as const;
+const NATIVE_GIT_CAPABILITIES = {
+  branch: true,
+  worktree: true
+} as const;
+
+export type GitProviderName = (typeof GIT_PROVIDER_NAMES)[number];
+export type GitProviderFallbackReason = "preferred_provider_unavailable";
+
+export interface GitProviderCapabilities {
+  branch: boolean;
+  worktree: boolean;
+}
+
+export interface GitRepositoryInput {
+  repo_root: string;
+}
+
+export interface GitCreateBranchInput extends GitRepositoryInput {
+  branch_name: string;
+  start_point?: string;
+}
+
+export interface GitCheckoutBranchInput extends GitRepositoryInput {
+  branch_name: string;
+}
+
+export interface GitAddWorktreeInput extends GitRepositoryInput {
+  worktree_path: string;
+  branch_name: string;
+  start_point?: string;
+  create_branch?: boolean;
+}
+
+export interface GitRemoveWorktreeInput extends GitRepositoryInput {
+  worktree_path: string;
+  force?: boolean;
+}
+
+export interface GitWorktreeInfo {
+  path: string;
+  branch_name?: string;
+  head: string;
+  bare: boolean;
+  detached: boolean;
+  is_current: boolean;
+}
+
+export interface GitProvider {
+  readonly name: GitProviderName;
+  readonly capabilities: GitProviderCapabilities;
+  isAvailable(): Promise<boolean>;
+  getCurrentBranch(input: GitRepositoryInput): Promise<string>;
+  createBranch(input: GitCreateBranchInput): Promise<void>;
+  checkoutBranch(input: GitCheckoutBranchInput): Promise<void>;
+  listWorktrees(input: GitRepositoryInput): Promise<GitWorktreeInfo[]>;
+  addWorktree(input: GitAddWorktreeInput): Promise<void>;
+  removeWorktree(input: GitRemoveWorktreeInput): Promise<void>;
+}
+
+export type GitProviderErrorCode =
+  | "provider_unavailable"
+  | "repository_not_found"
+  | "invalid_branch_name"
+  | "command_failed";
+
+export class GitProviderError extends Error {
+  readonly code: GitProviderErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: GitProviderErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "GitProviderError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface ResolveGitProviderInput {
+  preferred_provider?: GitProviderName;
+  git_binary?: string;
+}
+
+export interface GitProviderResolution {
+  provider: GitProvider;
+  selected_provider: GitProviderName;
+  preferred_provider?: GitProviderName;
+  fallback_used: boolean;
+  fallback_reason?: GitProviderFallbackReason;
+}
+
+/**
+ * Resolve the provider requested by policy, but fail over to native git when an
+ * experimental adapter target is unavailable. This keeps v1 execution grounded in
+ * a working path without blocking future provider expansion.
+ */
+export async function resolveGitProvider(
+  input: ResolveGitProviderInput = {}
+): Promise<GitProviderResolution> {
+  const nativeGitProvider = createNativeGitProvider({
+    ...(input.git_binary ? { git_binary: input.git_binary } : {})
+  });
+  const preferredProvider = input.preferred_provider ?? "native-git";
+
+  if (preferredProvider === "native-git") {
+    await ensureProviderAvailable(nativeGitProvider);
+    return {
+      provider: nativeGitProvider,
+      selected_provider: "native-git",
+      preferred_provider: preferredProvider,
+      fallback_used: false
+    };
+  }
+
+  const gitButlerProvider = createGitButlerPlaceholderProvider();
+  if (await gitButlerProvider.isAvailable()) {
+    return {
+      provider: gitButlerProvider,
+      selected_provider: "gitbutler",
+      preferred_provider: preferredProvider,
+      fallback_used: false
+    };
+  }
+
+  await ensureProviderAvailable(nativeGitProvider);
+  return {
+    provider: nativeGitProvider,
+    selected_provider: "native-git",
+    preferred_provider: preferredProvider,
+    fallback_used: true,
+    fallback_reason: "preferred_provider_unavailable"
+  };
+}
+
+export function createNativeGitProvider(input: { git_binary?: string } = {}): GitProvider {
+  return new NativeGitProvider(input.git_binary ?? "git");
+}
+
+function createGitButlerPlaceholderProvider(): GitProvider {
+  return {
+    name: "gitbutler",
+    capabilities: { ...NATIVE_GIT_CAPABILITIES },
+    async isAvailable() {
+      return false;
+    },
+    async getCurrentBranch() {
+      throw new GitProviderError(
+        "provider_unavailable",
+        "gitbutler provider is not available in this v1 implementation."
+      );
+    },
+    async createBranch() {
+      throw new GitProviderError(
+        "provider_unavailable",
+        "gitbutler provider is not available in this v1 implementation."
+      );
+    },
+    async checkoutBranch() {
+      throw new GitProviderError(
+        "provider_unavailable",
+        "gitbutler provider is not available in this v1 implementation."
+      );
+    },
+    async listWorktrees() {
+      throw new GitProviderError(
+        "provider_unavailable",
+        "gitbutler provider is not available in this v1 implementation."
+      );
+    },
+    async addWorktree() {
+      throw new GitProviderError(
+        "provider_unavailable",
+        "gitbutler provider is not available in this v1 implementation."
+      );
+    },
+    async removeWorktree() {
+      throw new GitProviderError(
+        "provider_unavailable",
+        "gitbutler provider is not available in this v1 implementation."
+      );
+    }
+  };
+}
+
+class NativeGitProvider implements GitProvider {
+  readonly name = "native-git" as const;
+  readonly capabilities: GitProviderCapabilities = { ...NATIVE_GIT_CAPABILITIES };
+
+  constructor(private readonly gitBinary: string) {}
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await execFileAsync(this.gitBinary, ["--version"], { encoding: "utf8" });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCurrentBranch(input: GitRepositoryInput): Promise<string> {
+    await ensureRepositoryExists(input.repo_root);
+
+    const output = await this.runGit(["branch", "--show-current"], input.repo_root);
+    const branchName = output.trim();
+    if (branchName.length === 0) {
+      throw new GitProviderError(
+        "command_failed",
+        `Repository at ${input.repo_root} is not on a named branch.`
+      );
+    }
+
+    return branchName;
+  }
+
+  async createBranch(input: GitCreateBranchInput): Promise<void> {
+    await ensureRepositoryExists(input.repo_root);
+    await this.ensureValidBranchName(input.branch_name);
+
+    await this.runGit(
+      ["branch", input.branch_name, ...(input.start_point ? [input.start_point] : [])],
+      input.repo_root
+    );
+  }
+
+  async checkoutBranch(input: GitCheckoutBranchInput): Promise<void> {
+    await ensureRepositoryExists(input.repo_root);
+    await this.ensureValidBranchName(input.branch_name);
+
+    await this.runGit(["checkout", input.branch_name], input.repo_root);
+  }
+
+  async listWorktrees(input: GitRepositoryInput): Promise<GitWorktreeInfo[]> {
+    await ensureRepositoryExists(input.repo_root);
+    const output = await this.runGit(["worktree", "list", "--porcelain"], input.repo_root);
+    return await parseWorktreeList(output, input.repo_root);
+  }
+
+  async addWorktree(input: GitAddWorktreeInput): Promise<void> {
+    await ensureRepositoryExists(input.repo_root);
+    await this.ensureValidBranchName(input.branch_name);
+
+    const createBranch = input.create_branch === true;
+    const args = ["worktree", "add"];
+
+    if (createBranch) {
+      args.push("-b", input.branch_name, input.worktree_path, input.start_point ?? "HEAD");
+    } else {
+      args.push(input.worktree_path, input.branch_name);
+    }
+
+    await this.runGit(args, input.repo_root);
+  }
+
+  async removeWorktree(input: GitRemoveWorktreeInput): Promise<void> {
+    await ensureRepositoryExists(input.repo_root);
+
+    await this.runGit(
+      ["worktree", "remove", ...(input.force ? ["--force"] : []), input.worktree_path],
+      input.repo_root
+    );
+  }
+
+  private async ensureValidBranchName(branchName: string): Promise<void> {
+    const normalizedBranchName = branchName.trim();
+    if (normalizedBranchName.length === 0) {
+      throw new GitProviderError("invalid_branch_name", "branch_name must be non-empty.");
+    }
+
+    try {
+      await execFileAsync(this.gitBinary, ["check-ref-format", "--branch", normalizedBranchName], {
+        encoding: "utf8"
+      });
+    } catch (error) {
+      throw new GitProviderError(
+        "invalid_branch_name",
+        `Invalid branch name: ${branchName}`,
+        error
+      );
+    }
+  }
+
+  private async runGit(args: string[], cwd?: string): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync(this.gitBinary, args, {
+        encoding: "utf8",
+        ...(cwd ? { cwd } : {})
+      });
+      return stdout.trim();
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new GitProviderError(
+          "provider_unavailable",
+          `Git binary was not found: ${this.gitBinary}`,
+          error
+        );
+      }
+
+      throw new GitProviderError(
+        "command_failed",
+        `Git command failed: ${this.gitBinary} ${args.join(" ")}`,
+        error
+      );
+    }
+  }
+}
+
+async function ensureProviderAvailable(provider: GitProvider): Promise<void> {
+  if (await provider.isAvailable()) {
+    return;
+  }
+
+  throw new GitProviderError(
+    "provider_unavailable",
+    `Preferred git provider is unavailable: ${provider.name}`
+  );
+}
+
+async function ensureRepositoryExists(repoRoot: string): Promise<void> {
+  try {
+    const stats = await lstat(repoRoot);
+    if (!stats.isDirectory()) {
+      throw new GitProviderError(
+        "repository_not_found",
+        `Repository root is not a directory: ${repoRoot}`
+      );
+    }
+  } catch (error) {
+    if (error instanceof GitProviderError) {
+      throw error;
+    }
+
+    throw new GitProviderError(
+      "repository_not_found",
+      `Repository root was not found: ${repoRoot}`,
+      error
+    );
+  }
+}
+
+/**
+ * Git emits worktree state as porcelain records separated by blank lines. We parse only
+ * the fields needed by current callers so later lifecycle code can stay provider-agnostic.
+ */
+async function parseWorktreeList(output: string, repoRoot: string): Promise<GitWorktreeInfo[]> {
+  const records = output
+    .split(/\n\s*\n/)
+    .map((chunk) => chunk.trim())
+    .filter((chunk) => chunk.length > 0);
+
+  const normalizedRepoRoot = await normalizeExistingPath(repoRoot);
+
+  const worktrees: GitWorktreeInfo[] = [];
+  for (const record of records) {
+    let path = "";
+    let branchName: string | undefined;
+    let head = "";
+    let bare = false;
+    let detached = false;
+
+    for (const line of record.split("\n")) {
+      if (line.startsWith("worktree ")) {
+        path = line.slice("worktree ".length);
+        continue;
+      }
+
+      if (line.startsWith("HEAD ")) {
+        head = line.slice("HEAD ".length);
+        continue;
+      }
+
+      if (line.startsWith("branch refs/heads/")) {
+        branchName = line.slice("branch refs/heads/".length);
+        continue;
+      }
+
+      if (line === "bare") {
+        bare = true;
+        continue;
+      }
+
+      if (line === "detached") {
+        detached = true;
+      }
+    }
+
+    const normalizedPath = await normalizeExistingPath(path);
+    worktrees.push({
+      path: normalizedPath,
+      ...(branchName ? { branch_name: branchName } : {}),
+      head,
+      bare,
+      detached,
+      is_current: normalizedPath === normalizedRepoRoot
+    });
+  }
+
+  return worktrees;
+}
+
+async function normalizeExistingPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return path;
+  }
+}

--- a/tests/execution/git-provider.test.ts
+++ b/tests/execution/git-provider.test.ts
@@ -1,0 +1,143 @@
+import { mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  GitProviderError,
+  createNativeGitProvider,
+  resolveGitProvider
+} from "../../src/core/git/provider.js";
+
+const execFileAsync = promisify(execFile);
+
+async function runGit(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout.trim();
+}
+
+async function createRepository(): Promise<string> {
+  const repoRoot = await mkdtemp(join(tmpdir(), "specforge-git-provider-"));
+
+  await runGit(["init"], repoRoot);
+  await runGit(["checkout", "-b", "main"], repoRoot);
+  await runGit(["config", "user.name", "SpecForge Tests"], repoRoot);
+  await runGit(["config", "user.email", "specforge@example.com"], repoRoot);
+
+  await writeFile(join(repoRoot, "README.md"), "# SpecForge test repo\n", "utf8");
+  await runGit(["add", "README.md"], repoRoot);
+  await runGit(["commit", "-m", "init"], repoRoot);
+
+  return repoRoot;
+}
+
+describe("git provider resolution", () => {
+  it("resolves native-git by default when git is available", async () => {
+    const resolution = await resolveGitProvider();
+
+    expect(resolution.selected_provider).toBe("native-git");
+    expect(resolution.fallback_used).toBe(false);
+    expect(resolution.provider.name).toBe("native-git");
+    expect(resolution.provider.capabilities.worktree).toBe(true);
+  });
+
+  it("falls back to native-git when the preferred gitbutler adapter is unavailable", async () => {
+    const resolution = await resolveGitProvider({
+      preferred_provider: "gitbutler"
+    });
+
+    expect(resolution.selected_provider).toBe("native-git");
+    expect(resolution.fallback_used).toBe(true);
+    expect(resolution.fallback_reason).toBe("preferred_provider_unavailable");
+  });
+});
+
+describe("native git provider branch and worktree primitives", () => {
+  it("reads the current branch and can create and checkout a branch", async () => {
+    const repoRoot = await createRepository();
+    const provider = createNativeGitProvider();
+
+    expect(await provider.getCurrentBranch({ repo_root: repoRoot })).toBe("main");
+
+    await provider.createBranch({
+      repo_root: repoRoot,
+      branch_name: "feat/task-1",
+      start_point: "HEAD"
+    });
+
+    expect(await runGit(["branch", "--list", "feat/task-1"], repoRoot)).toContain("feat/task-1");
+
+    await provider.checkoutBranch({
+      repo_root: repoRoot,
+      branch_name: "feat/task-1"
+    });
+
+    expect(await provider.getCurrentBranch({ repo_root: repoRoot })).toBe("feat/task-1");
+  });
+
+  it("adds and removes worktrees through the provider interface", async () => {
+    const repoRoot = await createRepository();
+    const provider = createNativeGitProvider();
+    const worktreePath = join(tmpdir(), `specforge-worktree-${Date.now()}`);
+
+    await provider.addWorktree({
+      repo_root: repoRoot,
+      worktree_path: worktreePath,
+      branch_name: "feat/task-2",
+      start_point: "HEAD",
+      create_branch: true
+    });
+
+    const normalizedWorktreePath = await realpath(worktreePath);
+    const worktrees = await provider.listWorktrees({ repo_root: repoRoot });
+    expect(worktrees.some((worktree) => worktree.path === normalizedWorktreePath)).toBe(true);
+    expect(worktrees.find((worktree) => worktree.path === normalizedWorktreePath)?.branch_name).toBe(
+      "feat/task-2"
+    );
+
+    await writeFile(join(worktreePath, "WORKTREE.md"), "worktree content\n", "utf8");
+    await runGit(["add", "WORKTREE.md"], worktreePath);
+    await runGit(["commit", "-m", "worktree commit"], worktreePath);
+
+    await provider.removeWorktree({
+      repo_root: repoRoot,
+      worktree_path: worktreePath,
+      force: true
+    });
+
+    const updatedWorktrees = await provider.listWorktrees({ repo_root: repoRoot });
+    expect(updatedWorktrees.some((worktree) => worktree.path === normalizedWorktreePath)).toBe(false);
+  });
+
+  it("fails with a typed error when branch names are invalid", async () => {
+    const repoRoot = await createRepository();
+    const provider = createNativeGitProvider();
+
+    await expect(
+      provider.createBranch({
+        repo_root: repoRoot,
+        branch_name: "",
+        start_point: "HEAD"
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<GitProviderError>>({
+        code: "invalid_branch_name"
+      })
+    );
+  });
+
+  it("surfaces typed repository errors for missing repositories", async () => {
+    const provider = createNativeGitProvider();
+
+    await expect(
+      provider.getCurrentBranch({ repo_root: "/tmp/specforge-missing-repo" })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<GitProviderError>>({
+        code: "repository_not_found"
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a provider-agnostic git abstraction with native git branch and worktree primitives
- resolve preferred providers with safe fallback to native git when the preferred adapter is unavailable
- cover native git behavior and fallback semantics with real repository/worktree tests

## Testing
- pnpm test
- pnpm typecheck
- pnpm build

Closes #25