### PR TITLE
feat: implement workspace isolation manager

### DIFF
--- a/src/core/execution/workspaceManager.ts
+++ b/src/core/execution/workspaceManager.ts
@@ -1,0 +1,312 @@
+import { lstat, mkdir, realpath } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  GitProviderError,
+  resolveGitProvider,
+  type GitProvider,
+  type GitProviderName,
+  type GitProviderResolution,
+  type GitWorktreeInfo
+} from "../git/provider.js";
+
+const DEFAULT_BRANCH_PREFIX = "feat";
+
+export type TaskWorkspaceManagerErrorCode =
+  | "invalid_task_id"
+  | "invalid_workspace_root"
+  | "workspace_conflict"
+  | "branch_in_use";
+
+export class TaskWorkspaceManagerError extends Error {
+  readonly code: TaskWorkspaceManagerErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: TaskWorkspaceManagerErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "TaskWorkspaceManagerError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface TaskWorkspaceTargetInput {
+  workspace_root: string;
+  task_id: string;
+  branch_name?: string;
+  branch_prefix?: string;
+}
+
+export interface TaskWorkspaceManagerInput extends TaskWorkspaceTargetInput {
+  repo_root: string;
+  start_point?: string;
+  preferred_provider?: GitProviderName;
+  git_binary?: string;
+  git_provider?: GitProvider;
+}
+
+export interface PrepareTaskWorkspaceResult {
+  task_id: string;
+  branch_name: string;
+  workspace_path: string;
+  created: boolean;
+  selected_provider: GitProviderName;
+  fallback_used: boolean;
+}
+
+export interface CleanupTaskWorkspaceResult {
+  task_id: string;
+  branch_name: string;
+  workspace_path: string;
+  removed: boolean;
+  selected_provider: GitProviderName;
+  fallback_used: boolean;
+}
+
+/**
+ * Prepare an isolated disposable git worktree for one execution task.
+ *
+ * The mapping from task_id to branch/path is deterministic so retries and cleanup can
+ * reason about the same workspace without hidden state. If a matching worktree already
+ * exists, we reuse it instead of creating duplicate checkouts for the same task branch.
+ */
+export async function prepareTaskWorkspace(
+  input: TaskWorkspaceManagerInput
+): Promise<PrepareTaskWorkspaceResult> {
+  const target = resolveTaskWorkspaceTarget(input);
+  const providerResolution = await resolveWorkspaceProvider(input);
+  const provider = providerResolution.provider;
+
+  await mkdir(target.workspace_root, { recursive: true });
+
+  const worktrees = await provider.listWorktrees({ repo_root: input.repo_root });
+  const normalizedWorkspacePath = await normalizePathIfExists(target.workspace_path);
+  const existingWorkspace = findWorktreeByPath(worktrees, normalizedWorkspacePath);
+  if (existingWorkspace) {
+    if (existingWorkspace.branch_name !== target.branch_name) {
+      throw new TaskWorkspaceManagerError(
+        "workspace_conflict",
+        `Workspace path ${target.workspace_path} is already attached to branch ${existingWorkspace.branch_name ?? "detached"}.`
+      );
+    }
+
+    return {
+      task_id: target.task_id,
+      branch_name: target.branch_name,
+      workspace_path: target.workspace_path,
+      created: false,
+      selected_provider: providerResolution.selected_provider,
+      fallback_used: providerResolution.fallback_used
+    };
+  }
+
+  if (await pathExists(target.workspace_path)) {
+    throw new TaskWorkspaceManagerError(
+      "workspace_conflict",
+      `Workspace path already exists outside git worktree management: ${target.workspace_path}`
+    );
+  }
+
+  const branchOwner = findWorktreeByBranch(worktrees, target.branch_name);
+  if (branchOwner) {
+    throw new TaskWorkspaceManagerError(
+      "branch_in_use",
+      `Branch ${target.branch_name} is already checked out in worktree ${branchOwner.path}.`
+    );
+  }
+
+  try {
+    await provider.addWorktree({
+      repo_root: input.repo_root,
+      worktree_path: target.workspace_path,
+      branch_name: target.branch_name,
+      start_point: input.start_point ?? "HEAD",
+      create_branch: true
+    });
+  } catch (error) {
+    if (!shouldRetryWithExistingBranch(error)) {
+      throw error;
+    }
+
+    // Cleanup removes disposable worktrees but intentionally leaves the task branch behind.
+    // A rerun should reattach that branch instead of failing closed on "already exists".
+    await provider.addWorktree({
+      repo_root: input.repo_root,
+      worktree_path: target.workspace_path,
+      branch_name: target.branch_name,
+      create_branch: false
+    });
+  }
+
+  return {
+    task_id: target.task_id,
+    branch_name: target.branch_name,
+    workspace_path: target.workspace_path,
+    created: true,
+    selected_provider: providerResolution.selected_provider,
+    fallback_used: providerResolution.fallback_used
+  };
+}
+
+/**
+ * Remove a disposable task worktree. Cleanup defaults to force mode because these
+ * workspaces are execution scratch space rather than user-owned feature branches.
+ */
+export async function cleanupTaskWorkspace(
+  input: TaskWorkspaceManagerInput & { force?: boolean }
+): Promise<CleanupTaskWorkspaceResult> {
+  const target = resolveTaskWorkspaceTarget(input);
+  const providerResolution = await resolveWorkspaceProvider(input);
+  const provider = providerResolution.provider;
+  const worktrees = await provider.listWorktrees({ repo_root: input.repo_root });
+  const normalizedWorkspacePath = await normalizePathIfExists(target.workspace_path);
+  const existingWorkspace = findWorktreeByPath(worktrees, normalizedWorkspacePath);
+
+  if (!existingWorkspace) {
+    if (await pathExists(target.workspace_path)) {
+      throw new TaskWorkspaceManagerError(
+        "workspace_conflict",
+        `Workspace path exists outside git worktree management: ${target.workspace_path}`
+      );
+    }
+
+    return {
+      task_id: target.task_id,
+      branch_name: target.branch_name,
+      workspace_path: target.workspace_path,
+      removed: false,
+      selected_provider: providerResolution.selected_provider,
+      fallback_used: providerResolution.fallback_used
+    };
+  }
+
+  if (existingWorkspace.branch_name !== target.branch_name) {
+    throw new TaskWorkspaceManagerError(
+      "workspace_conflict",
+      `Workspace path ${target.workspace_path} is attached to branch ${existingWorkspace.branch_name ?? "detached"}, not ${target.branch_name}.`
+    );
+  }
+
+  await provider.removeWorktree({
+    repo_root: input.repo_root,
+    worktree_path: target.workspace_path,
+    force: input.force ?? true
+  });
+
+  return {
+    task_id: target.task_id,
+    branch_name: target.branch_name,
+    workspace_path: target.workspace_path,
+    removed: true,
+    selected_provider: providerResolution.selected_provider,
+    fallback_used: providerResolution.fallback_used
+  };
+}
+
+export interface ResolvedTaskWorkspaceTarget {
+  task_id: string;
+  branch_name: string;
+  workspace_root: string;
+  workspace_path: string;
+  workspace_slug: string;
+}
+
+export function resolveTaskWorkspaceTarget(
+  input: TaskWorkspaceTargetInput
+): ResolvedTaskWorkspaceTarget {
+  const taskId = input.task_id.trim();
+  if (taskId.length === 0) {
+    throw new TaskWorkspaceManagerError("invalid_task_id", "task_id must be non-empty.");
+  }
+
+  const workspaceRoot = input.workspace_root.trim();
+  if (workspaceRoot.length === 0) {
+    throw new TaskWorkspaceManagerError(
+      "invalid_workspace_root",
+      "workspace_root must be non-empty."
+    );
+  }
+
+  const workspaceSlug = normalizeTaskWorkspaceSlug(taskId);
+  if (workspaceSlug.length === 0) {
+    throw new TaskWorkspaceManagerError(
+      "invalid_task_id",
+      `task_id ${taskId} does not produce a valid workspace target.`
+    );
+  }
+
+  const branchPrefix = (input.branch_prefix ?? DEFAULT_BRANCH_PREFIX).trim();
+  const branchName = input.branch_name?.trim() || `${branchPrefix}/${workspaceSlug}`;
+
+  return {
+    task_id: taskId,
+    branch_name: branchName,
+    workspace_root: workspaceRoot,
+    workspace_path: join(workspaceRoot, workspaceSlug),
+    workspace_slug: workspaceSlug
+  };
+}
+
+async function resolveWorkspaceProvider(
+  input: TaskWorkspaceManagerInput
+): Promise<GitProviderResolution> {
+  if (input.git_provider) {
+    return {
+      provider: input.git_provider,
+      selected_provider: input.git_provider.name,
+      preferred_provider: input.git_provider.name,
+      fallback_used: false
+    };
+  }
+
+  return await resolveGitProvider({
+    ...(input.preferred_provider ? { preferred_provider: input.preferred_provider } : {}),
+    ...(input.git_binary ? { git_binary: input.git_binary } : {})
+  });
+}
+
+function findWorktreeByPath(worktrees: GitWorktreeInfo[], workspacePath: string): GitWorktreeInfo | undefined {
+  return worktrees.find((worktree) => worktree.path === workspacePath);
+}
+
+function findWorktreeByBranch(
+  worktrees: GitWorktreeInfo[],
+  branchName: string
+): GitWorktreeInfo | undefined {
+  return worktrees.find((worktree) => worktree.branch_name === branchName);
+}
+
+function normalizeTaskWorkspaceSlug(taskId: string): string {
+  return taskId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function normalizePathIfExists(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return path;
+  }
+}
+
+function shouldRetryWithExistingBranch(error: unknown): boolean {
+  if (!(error instanceof GitProviderError) || error.code !== "command_failed") {
+    return false;
+  }
+
+  const originalError = error.details as { stderr?: unknown; message?: unknown } | undefined;
+  const stderr = typeof originalError?.stderr === "string" ? originalError.stderr : "";
+  const message = typeof originalError?.message === "string" ? originalError.message : "";
+  return stderr.includes("already exists") || message.includes("already exists");
+}

--- a/tests/execution/workspace-manager.test.ts
+++ b/tests/execution/workspace-manager.test.ts
@@ -1,0 +1,202 @@
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  TaskWorkspaceManagerError,
+  cleanupTaskWorkspace,
+  prepareTaskWorkspace
+} from "../../src/core/execution/workspaceManager.js";
+import { createNativeGitProvider } from "../../src/core/git/provider.js";
+
+const execFileAsync = promisify(execFile);
+
+async function runGit(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout.trim();
+}
+
+async function createRepository(): Promise<string> {
+  const repoRoot = await mkdtemp(join(tmpdir(), "specforge-workspace-manager-repo-"));
+
+  await runGit(["init"], repoRoot);
+  await runGit(["checkout", "-b", "main"], repoRoot);
+  await runGit(["config", "user.name", "SpecForge Tests"], repoRoot);
+  await runGit(["config", "user.email", "specforge@example.com"], repoRoot);
+
+  await writeFile(join(repoRoot, "README.md"), "# SpecForge test repo\n", "utf8");
+  await runGit(["add", "README.md"], repoRoot);
+  await runGit(["commit", "-m", "init"], repoRoot);
+
+  return repoRoot;
+}
+
+describe("workspace manager", () => {
+  it("creates a deterministic isolated worktree for a task", async () => {
+    const repoRoot = await createRepository();
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "specforge-workspaces-"));
+    const provider = createNativeGitProvider();
+
+    const result = await prepareTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      git_provider: provider
+    });
+
+    expect(result.branch_name).toBe("feat/task-1");
+    expect(result.workspace_path).toBe(join(workspaceRoot, "task-1"));
+    expect(result.created).toBe(true);
+    expect(await runGit(["branch", "--show-current"], result.workspace_path)).toBe("feat/task-1");
+  });
+
+  it("reuses the same task workspace without creating a duplicate worktree", async () => {
+    const repoRoot = await createRepository();
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "specforge-workspaces-"));
+    const provider = createNativeGitProvider();
+
+    const first = await prepareTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      git_provider: provider
+    });
+
+    const second = await prepareTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      git_provider: provider
+    });
+
+    expect(second.created).toBe(false);
+    expect(second.workspace_path).toBe(first.workspace_path);
+
+    const worktrees = await provider.listWorktrees({ repo_root: repoRoot });
+    expect(worktrees.filter((worktree) => worktree.branch_name === "feat/task-1")).toHaveLength(1);
+  });
+
+  it("recreates a cleaned task workspace even when the branch already exists", async () => {
+    const repoRoot = await createRepository();
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "specforge-workspaces-"));
+    const provider = createNativeGitProvider();
+
+    const first = await prepareTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      git_provider: provider
+    });
+
+    await cleanupTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      git_provider: provider
+    });
+
+    const second = await prepareTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      git_provider: provider
+    });
+
+    expect(second.created).toBe(true);
+    expect(second.branch_name).toBe(first.branch_name);
+    expect(second.workspace_path).toBe(first.workspace_path);
+    expect(await runGit(["branch", "--show-current"], second.workspace_path)).toBe("feat/task-1");
+  });
+
+  it("fails with a typed error when a target branch is already in use by another task workspace", async () => {
+    const repoRoot = await createRepository();
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "specforge-workspaces-"));
+    const provider = createNativeGitProvider();
+
+    await prepareTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      branch_name: "feat/shared-branch",
+      git_provider: provider
+    });
+
+    await expect(
+      prepareTaskWorkspace({
+        repo_root: repoRoot,
+        workspace_root: workspaceRoot,
+        task_id: "TASK-2",
+        branch_name: "feat/shared-branch",
+        git_provider: provider
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<TaskWorkspaceManagerError>>({
+        code: "branch_in_use"
+      })
+    );
+  });
+
+  it("force-cleans disposable task worktrees and no-ops after removal", async () => {
+    const repoRoot = await createRepository();
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "specforge-workspaces-"));
+    const provider = createNativeGitProvider();
+
+    const result = await prepareTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      git_provider: provider
+    });
+
+    await writeFile(join(result.workspace_path, "DIRTY.md"), "dirty\n", "utf8");
+
+    const removed = await cleanupTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      git_provider: provider
+    });
+
+    expect(removed.removed).toBe(true);
+
+    const worktrees = await provider.listWorktrees({ repo_root: repoRoot });
+    const normalizedWorktreePath = await realpath(join(workspaceRoot));
+    expect(
+      worktrees.some((worktree) => worktree.path.startsWith(normalizedWorktreePath) && worktree.branch_name === "feat/task-1")
+    ).toBe(false);
+
+    const secondRemoval = await cleanupTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      git_provider: provider
+    });
+
+    expect(secondRemoval.removed).toBe(false);
+
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("fails with a typed error when task_id cannot produce a workspace target", async () => {
+    const repoRoot = await createRepository();
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "specforge-workspaces-"));
+    const provider = createNativeGitProvider();
+
+    await expect(
+      prepareTaskWorkspace({
+        repo_root: repoRoot,
+        workspace_root: workspaceRoot,
+        task_id: "___",
+        git_provider: provider
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<TaskWorkspaceManagerError>>({
+        code: "invalid_task_id"
+      })
+    );
+  });
+});


### PR DESCRIPTION
Closes #27

## Summary
- add a deterministic workspace manager for task-scoped git worktree isolation
- support prepare and cleanup lifecycle paths with branch reuse after cleanup
- add real git-backed tests for workspace reuse, branch conflicts, and force cleanup