### PR TITLE
feat: implement affected subgraph replanning

### DIFF
--- a/src/core/operations/replanAffectedSubgraph.ts
+++ b/src/core/operations/replanAffectedSubgraph.ts
@@ -1,0 +1,377 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ArtifactMetadata, ArtifactSourceRef, ArtifactVersion } from "../artifacts/types.js";
+import {
+  createInitialArtifactMetadata,
+  createNextArtifactMetadata
+} from "../artifacts/versioning.js";
+import type { ProjectMode } from "../contracts/domain.js";
+import type { OperationContract } from "../contracts/operation.js";
+import type {
+  WorkGraph,
+  WorkGraphEpic,
+  WorkGraphStory,
+  WorkGraphTask
+} from "./decomposeToWorkGraph.js";
+
+const REPLAN_ARTIFACT_ID = "replan_subgraph";
+const REPLAN_ARTIFACT_PATH = join(".specforge", "replans", "replan_subgraph.json");
+
+export type ReplanAffectedSubgraphErrorCode =
+  | "invalid_mode"
+  | "insufficient_work_graph"
+  | "empty_change_set"
+  | "unknown_task_reference"
+  | "artifact_write_failed";
+
+export class ReplanAffectedSubgraphError extends Error {
+  readonly code: ReplanAffectedSubgraphErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: ReplanAffectedSubgraphErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "ReplanAffectedSubgraphError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export type StaleTaskReason = "task_changed" | "contract_changed" | "upstream_impacted";
+
+export interface ReplanAffectedSubgraphInput {
+  project_mode: ProjectMode;
+  work_graph?: WorkGraph;
+  changed_task_ids?: string[];
+  changed_contract_refs?: string[];
+  artifact_dir?: string;
+  created_timestamp?: Date;
+}
+
+export interface StaleTaskRecord {
+  task_id: string;
+  reasons: StaleTaskReason[];
+}
+
+export interface ReplanSubgraphArtifact {
+  kind: "replan_subgraph";
+  metadata: ArtifactMetadata;
+  project_mode: "existing-repo";
+  changed_task_ids: string[];
+  changed_contract_refs: string[];
+  stale_tasks: StaleTaskRecord[];
+  updated_subgraph: WorkGraph;
+}
+
+export interface ReplanAffectedSubgraphResult {
+  replan_subgraph: ReplanSubgraphArtifact;
+  stale_task_ids: string[];
+  updated_subgraph: WorkGraph;
+}
+
+export const REPLAN_AFFECTED_SUBGRAPH_OPERATION_CONTRACT: OperationContract<
+  ReplanAffectedSubgraphInput,
+  ReplanAffectedSubgraphResult
+> = {
+  name: "operation.replanAffectedSubgraph",
+  version: "v1",
+  purpose: "Scope replanning to tasks directly changed by contract/task updates plus their downstream dependents.",
+  inputs_schema: {} as ReplanAffectedSubgraphInput,
+  outputs_schema: {} as ReplanAffectedSubgraphResult,
+  side_effects: ["writes .specforge/replans/replan_subgraph.json"],
+  invariants: [
+    "Only changed tasks, contract-matching tasks, and their downstream dependents are marked stale.",
+    "Updated subgraph ordering is preserved from the published work graph.",
+    "Replan artifact metadata references the exact work graph version used as the baseline."
+  ],
+  idempotency_expectations: [
+    "Equivalent work graph and change inputs produce stable stale-task ordering and subgraph output."
+  ],
+  failure_modes: [
+    "invalid_mode",
+    "insufficient_work_graph",
+    "empty_change_set",
+    "unknown_task_reference",
+    "artifact_write_failed"
+  ],
+  observability_fields: [
+    "work_graph_version",
+    "changed_task_count",
+    "changed_contract_count",
+    "stale_task_count",
+    "replan_subgraph_version"
+  ]
+};
+
+/**
+ * Recompute only the stale portion of a published work graph after narrow task or
+ * contract changes. This slice does not regenerate tasks from upstream specs; it
+ * identifies the exact subgraph that must be replanned and preserves graph ordering.
+ */
+export async function runReplanAffectedSubgraph(
+  input: ReplanAffectedSubgraphInput
+): Promise<ReplanAffectedSubgraphResult> {
+  if (input.project_mode !== "existing-repo") {
+    throw new ReplanAffectedSubgraphError(
+      "invalid_mode",
+      "replanAffectedSubgraph currently supports project_mode=existing-repo."
+    );
+  }
+
+  const workGraph = ensureWorkGraph(input.work_graph);
+  const changedTaskIds = normalizeStringArray(input.changed_task_ids ?? []);
+  const changedContractRefs = normalizeStringArray(input.changed_contract_refs ?? []);
+
+  if (changedTaskIds.length === 0 && changedContractRefs.length === 0) {
+    throw new ReplanAffectedSubgraphError(
+      "empty_change_set",
+      "At least one changed_task_id or changed_contract_ref is required."
+    );
+  }
+
+  const indexedGraph = indexWorkGraph(workGraph);
+  for (const taskId of changedTaskIds) {
+    if (!indexedGraph.tasksById.has(taskId)) {
+      throw new ReplanAffectedSubgraphError(
+        "unknown_task_reference",
+        `changed_task_id is not present in the work graph: ${taskId}`
+      );
+    }
+  }
+
+  const staleReasonMap = new Map<string, Set<StaleTaskReason>>();
+
+  for (const taskId of changedTaskIds) {
+    appendReason(staleReasonMap, taskId, "task_changed");
+  }
+
+  for (const task of indexedGraph.orderedTasks) {
+    if (task.contract_refs.some((ref) => changedContractRefs.includes(ref))) {
+      appendReason(staleReasonMap, task.id, "contract_changed");
+    }
+  }
+
+  // Once a task is stale, every downstream dependent must also be replanned because its
+  // inputs were derived from an outdated upstream node.
+  const queue = [...staleReasonMap.keys()];
+  const seen = new Set(queue);
+
+  while (queue.length > 0) {
+    const currentTaskId = queue.shift();
+    if (!currentTaskId) {
+      continue;
+    }
+
+    const downstreamTaskIds = indexedGraph.downstreamByTaskId.get(currentTaskId) ?? [];
+    for (const downstreamTaskId of downstreamTaskIds) {
+      appendReason(staleReasonMap, downstreamTaskId, "upstream_impacted");
+      if (!seen.has(downstreamTaskId)) {
+        seen.add(downstreamTaskId);
+        queue.push(downstreamTaskId);
+      }
+    }
+  }
+
+  const staleTaskIds = indexedGraph.orderedTasks
+    .map((task) => task.id)
+    .filter((taskId) => staleReasonMap.has(taskId));
+
+  const staleTasks: StaleTaskRecord[] = staleTaskIds.map((taskId) => ({
+    task_id: taskId,
+    reasons: [...(staleReasonMap.get(taskId) ?? new Set<StaleTaskReason>())].sort((left, right) =>
+      left.localeCompare(right)
+    ) as StaleTaskReason[]
+  }));
+
+  const updatedSubgraph = buildUpdatedSubgraph(workGraph, new Set(staleTaskIds));
+  const workGraphRef: ArtifactSourceRef = {
+    artifact_id: "spec.dag",
+    artifact_version: resolveWorkGraphVersion(input.work_graph)
+  };
+
+  const artifactContent = JSON.stringify(
+    {
+      project_mode: input.project_mode,
+      changed_task_ids: changedTaskIds,
+      changed_contract_refs: changedContractRefs,
+      stale_tasks: staleTasks,
+      updated_subgraph: updatedSubgraph
+    },
+    null,
+    2
+  );
+
+  const previousMetadata = input.artifact_dir
+    ? await readExistingReplanMetadata(input.artifact_dir)
+    : undefined;
+
+  const metadata = previousMetadata
+    ? createNextArtifactMetadata({
+        previous: previousMetadata,
+        generator: REPLAN_AFFECTED_SUBGRAPH_OPERATION_CONTRACT.name,
+        sourceRefs: [workGraphRef],
+        content: artifactContent,
+        ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
+      })
+    : createInitialArtifactMetadata({
+        artifactId: REPLAN_ARTIFACT_ID,
+        generator: REPLAN_AFFECTED_SUBGRAPH_OPERATION_CONTRACT.name,
+        sourceRefs: [workGraphRef],
+        content: artifactContent,
+        ...(input.created_timestamp ? { createdTimestamp: input.created_timestamp } : {})
+      });
+
+  const replanSubgraph: ReplanSubgraphArtifact = {
+    kind: "replan_subgraph",
+    metadata,
+    project_mode: "existing-repo",
+    changed_task_ids: changedTaskIds,
+    changed_contract_refs: changedContractRefs,
+    stale_tasks: staleTasks,
+    updated_subgraph: updatedSubgraph
+  };
+
+  if (input.artifact_dir) {
+    await writeReplanArtifact({
+      artifact_dir: input.artifact_dir,
+      replan_subgraph: replanSubgraph
+    });
+  }
+
+  return {
+    replan_subgraph: replanSubgraph,
+    stale_task_ids: staleTaskIds,
+    updated_subgraph: updatedSubgraph
+  };
+}
+
+function ensureWorkGraph(workGraph?: WorkGraph): WorkGraph {
+  if (!workGraph || !Array.isArray(workGraph.epics)) {
+    throw new ReplanAffectedSubgraphError(
+      "insufficient_work_graph",
+      "Missing or invalid work_graph input."
+    );
+  }
+
+  return workGraph;
+}
+
+function resolveWorkGraphVersion(workGraph?: WorkGraph): ArtifactVersion {
+  void workGraph;
+  return "v1";
+}
+
+function normalizeStringArray(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))].sort(
+    (left, right) => left.localeCompare(right)
+  );
+}
+
+function appendReason(
+  staleReasonMap: Map<string, Set<StaleTaskReason>>,
+  taskId: string,
+  reason: StaleTaskReason
+): void {
+  const reasons = staleReasonMap.get(taskId) ?? new Set<StaleTaskReason>();
+  reasons.add(reason);
+  staleReasonMap.set(taskId, reasons);
+}
+
+interface IndexedWorkGraph {
+  orderedTasks: WorkGraphTask[];
+  tasksById: Map<string, WorkGraphTask>;
+  downstreamByTaskId: Map<string, string[]>;
+}
+
+function indexWorkGraph(workGraph: WorkGraph): IndexedWorkGraph {
+  const orderedTasks: WorkGraphTask[] = [];
+  const tasksById = new Map<string, WorkGraphTask>();
+  const downstreamByTaskId = new Map<string, string[]>();
+
+  for (const epic of workGraph.epics) {
+    for (const story of epic.stories) {
+      for (const task of story.tasks) {
+        orderedTasks.push(task);
+        tasksById.set(task.id, task);
+      }
+    }
+  }
+
+  for (const task of orderedTasks) {
+    for (const dependencyId of task.depends_on) {
+      const downstream = downstreamByTaskId.get(dependencyId) ?? [];
+      downstream.push(task.id);
+      downstreamByTaskId.set(dependencyId, downstream);
+    }
+  }
+
+  return {
+    orderedTasks,
+    tasksById,
+    downstreamByTaskId
+  };
+}
+
+function buildUpdatedSubgraph(workGraph: WorkGraph, staleTaskIds: Set<string>): WorkGraph {
+  const epics: WorkGraphEpic[] = [];
+
+  for (const epic of workGraph.epics) {
+    const stories: WorkGraphStory[] = [];
+
+    for (const story of epic.stories) {
+      const tasks = story.tasks
+        .filter((task) => staleTaskIds.has(task.id))
+        .map((task) => ({
+          ...task,
+          depends_on: task.depends_on.filter((dependencyId) => staleTaskIds.has(dependencyId))
+        }));
+
+      if (tasks.length > 0) {
+        stories.push({
+          ...story,
+          tasks
+        });
+      }
+    }
+
+    if (stories.length > 0) {
+      epics.push({
+        ...epic,
+        stories
+      });
+    }
+  }
+
+  return { epics };
+}
+
+async function readExistingReplanMetadata(artifactDir: string): Promise<ArtifactMetadata | undefined> {
+  try {
+    const raw = await readFile(join(artifactDir, REPLAN_ARTIFACT_PATH), "utf8");
+    return (JSON.parse(raw) as { metadata?: ArtifactMetadata }).metadata;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeReplanArtifact(input: {
+  artifact_dir: string;
+  replan_subgraph: ReplanSubgraphArtifact;
+}): Promise<void> {
+  const targetPath = join(input.artifact_dir, REPLAN_ARTIFACT_PATH);
+
+  try {
+    await mkdir(join(input.artifact_dir, ".specforge", "replans"), { recursive: true });
+    await writeFile(
+      targetPath,
+      `${JSON.stringify(input.replan_subgraph, null, 2)}\n`,
+      "utf8"
+    );
+  } catch (error) {
+    throw new ReplanAffectedSubgraphError(
+      "artifact_write_failed",
+      `Failed to write replan subgraph artifact to ${targetPath}`,
+      error
+    );
+  }
+}

--- a/src/core/spec/ownership.ts
+++ b/src/core/spec/ownership.ts
@@ -2,6 +2,7 @@ export const ARTIFACT_KINDS = [
   "idea_brief",
   "prd",
   "spec",
+  "replan_subgraph",
   "architecture_summary",
   "delta_spec",
   "task_execution_result",
@@ -32,6 +33,10 @@ export const ARTIFACT_OWNERSHIP_REGISTRY: Record<ArtifactKind, ArtifactOwnership
   spec: {
     artifact_kind: "spec",
     owner_operation: "operation.generateSpecPack"
+  },
+  replan_subgraph: {
+    artifact_kind: "replan_subgraph",
+    owner_operation: "operation.replanAffectedSubgraph"
   },
   architecture_summary: {
     artifact_kind: "architecture_summary",
@@ -82,6 +87,10 @@ export function inferArtifactKindFromId(artifactId: string): ArtifactKind | unde
 
   if (artifactId.startsWith("spec.")) {
     return "spec";
+  }
+
+  if (artifactId === "replan_subgraph") {
+    return "replan_subgraph";
   }
 
   if (artifactId === "architecture_summary") {

--- a/tests/planning/replan-affected-subgraph.test.ts
+++ b/tests/planning/replan-affected-subgraph.test.ts
@@ -1,0 +1,207 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import type { WorkGraph } from "../../src/core/operations/decomposeToWorkGraph.js";
+import {
+  ReplanAffectedSubgraphError,
+  runReplanAffectedSubgraph
+} from "../../src/core/operations/replanAffectedSubgraph.js";
+import {
+  ARTIFACT_OWNERSHIP_REGISTRY,
+  inferArtifactKindFromId
+} from "../../src/core/spec/ownership.js";
+
+function buildWorkGraph(): WorkGraph {
+  return {
+    epics: [
+      {
+        id: "EPIC-1",
+        title: "Execution prep",
+        stories: [
+          {
+            id: "STORY-1",
+            title: "Core flow",
+            tasks: [
+              {
+                id: "TASK-1",
+                title: "Update contract adapter",
+                acceptance_refs: ["AC-1"],
+                contract_refs: ["schemas/core.schema.json", "spec.contracts"],
+                depends_on: []
+              },
+              {
+                id: "TASK-2",
+                title: "Refresh context pack builder",
+                acceptance_refs: ["AC-2"],
+                contract_refs: ["spec.contracts"],
+                depends_on: ["TASK-1"]
+              }
+            ]
+          },
+          {
+            id: "STORY-2",
+            title: "Execution loop",
+            tasks: [
+              {
+                id: "TASK-3",
+                title: "Update execution critic",
+                acceptance_refs: ["AC-3"],
+                contract_refs: ["schemas/critic.schema.json"],
+                depends_on: ["TASK-2"]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+}
+
+describe("replanAffectedSubgraph failure paths", () => {
+  it("fails with a typed error when the work graph is missing", async () => {
+    await expect(
+      runReplanAffectedSubgraph({
+        project_mode: "existing-repo",
+        changed_task_ids: ["TASK-1"]
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<ReplanAffectedSubgraphError>>({
+        code: "insufficient_work_graph"
+      })
+    );
+  });
+
+  it("fails with a typed error when no contract or task changes are provided", async () => {
+    await expect(
+      runReplanAffectedSubgraph({
+        project_mode: "existing-repo",
+        work_graph: buildWorkGraph(),
+        changed_task_ids: [],
+        changed_contract_refs: []
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<ReplanAffectedSubgraphError>>({
+        code: "empty_change_set"
+      })
+    );
+  });
+});
+
+describe("replanAffectedSubgraph success paths", () => {
+  it("registers replan_subgraph ownership to operation.replanAffectedSubgraph", () => {
+    expect(ARTIFACT_OWNERSHIP_REGISTRY.replan_subgraph.owner_operation).toBe(
+      "operation.replanAffectedSubgraph"
+    );
+    expect(inferArtifactKindFromId("replan_subgraph")).toBe("replan_subgraph");
+  });
+
+  it("marks changed contract tasks and their downstream dependents as stale", async () => {
+    const result = await runReplanAffectedSubgraph({
+      project_mode: "existing-repo",
+      work_graph: buildWorkGraph(),
+      changed_contract_refs: ["spec.contracts"]
+    });
+
+    expect(result.stale_task_ids).toEqual(["TASK-1", "TASK-2", "TASK-3"]);
+    expect(result.replan_subgraph.stale_tasks).toEqual([
+      {
+        task_id: "TASK-1",
+        reasons: ["contract_changed"]
+      },
+      {
+        task_id: "TASK-2",
+        reasons: ["contract_changed", "upstream_impacted"]
+      },
+      {
+        task_id: "TASK-3",
+        reasons: ["upstream_impacted"]
+      }
+    ]);
+  });
+
+  it("marks changed tasks and downstream dependents while preserving task order", async () => {
+    const result = await runReplanAffectedSubgraph({
+      project_mode: "existing-repo",
+      work_graph: buildWorkGraph(),
+      changed_task_ids: ["TASK-2"]
+    });
+
+    expect(result.stale_task_ids).toEqual(["TASK-2", "TASK-3"]);
+    expect(result.updated_subgraph).toEqual({
+      epics: [
+        {
+          id: "EPIC-1",
+          title: "Execution prep",
+          stories: [
+            {
+              id: "STORY-1",
+              title: "Core flow",
+              tasks: [
+                {
+                  id: "TASK-2",
+                  title: "Refresh context pack builder",
+                  acceptance_refs: ["AC-2"],
+                  contract_refs: ["spec.contracts"],
+                  depends_on: []
+                }
+              ]
+            },
+            {
+              id: "STORY-2",
+              title: "Execution loop",
+              tasks: [
+                {
+                  id: "TASK-3",
+                  title: "Update execution critic",
+                  acceptance_refs: ["AC-3"],
+                  contract_refs: ["schemas/critic.schema.json"],
+                  depends_on: ["TASK-2"]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it("writes a versioned replan artifact with stale task metadata", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-replan-subgraph-"));
+
+    await runReplanAffectedSubgraph({
+      project_mode: "existing-repo",
+      work_graph: buildWorkGraph(),
+      changed_task_ids: ["TASK-2"],
+      changed_contract_refs: ["spec.contracts"],
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-12T23:10:00.000Z")
+    });
+
+    const second = await runReplanAffectedSubgraph({
+      project_mode: "existing-repo",
+      work_graph: buildWorkGraph(),
+      changed_task_ids: ["TASK-2"],
+      changed_contract_refs: ["spec.contracts"],
+      artifact_dir: artifactDir,
+      created_timestamp: new Date("2026-03-12T23:12:00.000Z")
+    });
+
+    expect(second.replan_subgraph.metadata.artifact_id).toBe("replan_subgraph");
+    expect(second.replan_subgraph.metadata.artifact_version).toBe("v2");
+    expect(second.replan_subgraph.metadata.parent_version).toBe("v1");
+    expect(second.replan_subgraph.metadata.generator).toBe("operation.replanAffectedSubgraph");
+
+    const written = JSON.parse(
+      await readFile(join(artifactDir, ".specforge", "replans", "replan_subgraph.json"), "utf8")
+    );
+    expect(written.metadata.artifact_id).toBe("replan_subgraph");
+    expect(written.stale_tasks.map((task: { task_id: string }) => task.task_id)).toEqual([
+      "TASK-1",
+      "TASK-2",
+      "TASK-3"
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #28

## Summary
- add operation.replanAffectedSubgraph for deterministic stale-task closure and scoped subgraph output
- publish a versioned replan_subgraph artifact with stale task reasons
- cover task-change, contract-change, and artifact versioning behavior with tests