### PR TITLE
feat: implement sf doctor diagnostics

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,18 +1,96 @@
 import { Command } from "commander";
+import { pathToFileURL } from "node:url";
 
-const program = new Command();
+import {
+  formatDoctorReport,
+  runDoctor,
+  type DoctorResult,
+  type RunDoctorInput
+} from "./core/diagnostics/doctor.js";
 
-program
-  .name("specforge")
-  .description("Specification-driven engineering orchestration CLI")
-  .version("0.1.0");
+interface CliWriter {
+  write(chunk: string): boolean | void;
+}
 
-program
-  .command("start")
-  .description("Start a SpecForge run (scaffold placeholder)")
-  .action(() => {
-    process.stdout.write("SpecForge CLI scaffold ready.\n");
-  });
+export interface CliDependencies {
+  stdout?: CliWriter;
+  stderr?: CliWriter;
+  doctor_runner?: (input?: RunDoctorInput) => Promise<DoctorResult>;
+  doctor_input?: RunDoctorInput;
+}
 
-program.parse(process.argv);
+class CliExitSignal extends Error {
+  readonly exitCode: number;
 
+  constructor(exitCode: number) {
+    super(`CLI exited with code ${exitCode}`);
+    this.name = "CliExitSignal";
+    this.exitCode = exitCode;
+  }
+}
+
+export function createProgram(dependencies: CliDependencies = {}): Command {
+  const stdout = dependencies.stdout ?? process.stdout;
+  const doctorRunner = dependencies.doctor_runner ?? runDoctor;
+  const doctorInput = dependencies.doctor_input;
+  const program = new Command();
+
+  program
+    .name("specforge")
+    .description("Specification-driven engineering orchestration CLI")
+    .version("0.1.0");
+
+  program
+    .command("start")
+    .description("Start a SpecForge run (scaffold placeholder)")
+    .action(() => {
+      stdout.write("SpecForge CLI scaffold ready.\n");
+    });
+
+  program
+    .command("doctor")
+    .description("Check environment, tooling, repository, and policy readiness")
+    .action(async () => {
+      const result = await doctorRunner({
+        cwd: process.cwd(),
+        ...(doctorInput ?? {})
+      });
+
+      stdout.write(formatDoctorReport(result));
+
+      if (result.overall_status === "fail") {
+        throw new CliExitSignal(1);
+      }
+    });
+
+  return program;
+}
+
+export async function runCli(argv: string[] = process.argv, dependencies: CliDependencies = {}): Promise<number> {
+  const program = createProgram(dependencies);
+
+  try {
+    await program.parseAsync(argv);
+    return 0;
+  } catch (error) {
+    if (error instanceof CliExitSignal) {
+      return error.exitCode;
+    }
+
+    throw error;
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    process.exitCode = await runCli(process.argv);
+  } catch (error) {
+    const stderr = process.stderr;
+    stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main();
+}

--- a/src/core/diagnostics/doctor.ts
+++ b/src/core/diagnostics/doctor.ts
@@ -1,0 +1,263 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { ARTIFACT_GATES, PROJECT_MODES } from "../contracts/domain.js";
+import {
+  createDefaultPolicyConfig,
+  type SpecForgePolicyConfig
+} from "../contracts/policy.js";
+
+const execFileAsync = promisify(execFile);
+const MINIMUM_NODE_MAJOR = 22;
+
+export type DoctorStatus = "pass" | "fail";
+
+export interface DoctorCheck {
+  id: string;
+  label: string;
+  status: DoctorStatus;
+  message: string;
+  remediation?: string;
+}
+
+export interface DoctorSummary {
+  passed: number;
+  failed: number;
+}
+
+export interface DoctorResult {
+  overall_status: DoctorStatus;
+  checks: DoctorCheck[];
+  summary: DoctorSummary;
+}
+
+export interface DoctorCommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export type DoctorCommandRunner = (
+  command: string,
+  args: string[],
+  options?: { cwd?: string }
+) => Promise<DoctorCommandResult>;
+
+export interface RunDoctorInput {
+  cwd?: string;
+  node_version?: string;
+  policy?: SpecForgePolicyConfig;
+  command_runner?: DoctorCommandRunner;
+}
+
+/**
+ * Run deterministic environment and policy checks for local execution readiness.
+ *
+ * The doctor command stays intentionally bounded in v1: it validates the runtime,
+ * required tooling, repository presence, and policy shape without mutating repo state.
+ */
+export async function runDoctor(input: RunDoctorInput = {}): Promise<DoctorResult> {
+  const cwd = input.cwd ?? process.cwd();
+  const nodeVersion = input.node_version ?? process.version;
+  const policy = input.policy ?? createDefaultPolicyConfig();
+  const commandRunner = input.command_runner ?? defaultCommandRunner;
+  const checks: DoctorCheck[] = [];
+
+  checks.push(checkNodeVersion(nodeVersion));
+
+  const gitCheck = await checkBinary({
+    id: "git_binary",
+    label: "Git binary",
+    command: "git",
+    args: ["--version"],
+    remediation: "Install git and ensure it is available on PATH.",
+    command_runner: commandRunner
+  });
+  checks.push(gitCheck);
+
+  const pnpmCheck = await checkBinary({
+    id: "pnpm_binary",
+    label: "pnpm package manager",
+    command: "pnpm",
+    args: ["--version"],
+    remediation: "Install pnpm and ensure it is available on PATH.",
+    command_runner: commandRunner
+  });
+  checks.push(pnpmCheck);
+
+  checks.push(await checkRepositoryRoot({ cwd, git_check: gitCheck, command_runner: commandRunner }));
+  checks.push(checkPolicyConfig(policy));
+
+  const summary = {
+    passed: checks.filter((check) => check.status === "pass").length,
+    failed: checks.filter((check) => check.status === "fail").length
+  };
+
+  return {
+    overall_status: summary.failed > 0 ? "fail" : "pass",
+    checks,
+    summary
+  };
+}
+
+export function formatDoctorReport(result: DoctorResult): string {
+  const lines = ["SpecForge Doctor", ""];
+
+  for (const check of result.checks) {
+    lines.push(`${check.status === "pass" ? "PASS" : "FAIL"} ${check.id} - ${check.message}`);
+    if (check.remediation) {
+      lines.push(`  Remediation: ${check.remediation}`);
+    }
+  }
+
+  lines.push("");
+  lines.push(`Summary: ${result.summary.passed} passed, ${result.summary.failed} failed`);
+  lines.push(`Overall: ${result.overall_status.toUpperCase()}`);
+
+  return `${lines.join("\n")}\n`;
+}
+
+function checkNodeVersion(nodeVersion: string): DoctorCheck {
+  const match = /^v(\d+)(?:\.\d+){0,2}$/.exec(nodeVersion.trim());
+  const major = match?.[1] ? Number.parseInt(match[1], 10) : Number.NaN;
+
+  if (!Number.isFinite(major) || major < MINIMUM_NODE_MAJOR) {
+    return {
+      id: "node_version",
+      label: "Node.js runtime",
+      status: "fail",
+      message: `Detected ${nodeVersion}, but SpecForge requires Node.js ${MINIMUM_NODE_MAJOR} LTS or newer.`,
+      remediation: `Install Node.js ${MINIMUM_NODE_MAJOR} LTS or newer and re-run sf doctor.`
+    };
+  }
+
+  return {
+    id: "node_version",
+    label: "Node.js runtime",
+    status: "pass",
+    message: `Node.js ${nodeVersion.replace(/^v/, "")} satisfies the minimum runtime requirement.`
+  };
+}
+
+async function checkBinary(input: {
+  id: string;
+  label: string;
+  command: string;
+  args: string[];
+  remediation: string;
+  command_runner: DoctorCommandRunner;
+}): Promise<DoctorCheck> {
+  try {
+    const result = await input.command_runner(input.command, input.args);
+    const version = result.stdout.trim() || result.stderr.trim() || "available";
+
+    return {
+      id: input.id,
+      label: input.label,
+      status: "pass",
+      message: `${input.label} detected: ${version}.`
+    };
+  } catch {
+    return {
+      id: input.id,
+      label: input.label,
+      status: "fail",
+      message: `${input.label} was not found on PATH.`,
+      remediation: input.remediation
+    };
+  }
+}
+
+async function checkRepositoryRoot(input: {
+  cwd: string;
+  git_check: DoctorCheck;
+  command_runner: DoctorCommandRunner;
+}): Promise<DoctorCheck> {
+  if (input.git_check.status === "fail") {
+    return {
+      id: "repository_root",
+      label: "Repository root",
+      status: "fail",
+      message: "Repository readiness could not be validated because git is unavailable.",
+      remediation: "Initialize or open a git repository before running execution commands."
+    };
+  }
+
+  try {
+    const result = await input.command_runner("git", ["rev-parse", "--show-toplevel"], {
+      cwd: input.cwd
+    });
+    const repoRoot = result.stdout.trim();
+
+    if (repoRoot.length === 0) {
+      throw new Error("empty repo root");
+    }
+
+    return {
+      id: "repository_root",
+      label: "Repository root",
+      status: "pass",
+      message: `Git repository detected at ${repoRoot}.`
+    };
+  } catch {
+    return {
+      id: "repository_root",
+      label: "Repository root",
+      status: "fail",
+      message: "Current working directory is not inside a git repository.",
+      remediation: "Initialize or open a git repository before running execution commands."
+    };
+  }
+}
+
+function checkPolicyConfig(policy: SpecForgePolicyConfig): DoctorCheck {
+  const gateKeys = Object.keys(policy.gates.enabled_by_default);
+  const enabledGatesValid =
+    gateKeys.length === ARTIFACT_GATES.length &&
+    ARTIFACT_GATES.every((gate) => typeof policy.gates.enabled_by_default[gate] === "boolean");
+
+  const applicableModesValid = Object.values(policy.gates.applicable_project_modes).every((modes) =>
+    (modes ?? []).every((mode) => PROJECT_MODES.includes(mode))
+  );
+
+  const parallelismValid =
+    Number.isInteger(policy.parallelism.max_concurrent_tasks) &&
+    policy.parallelism.max_concurrent_tasks > 0 &&
+    typeof policy.parallelism.serialize_on_uncertainty === "boolean";
+
+  const coverageValid =
+    policy.coverage.scope === "changed-lines" &&
+    (policy.coverage.enforcement === "report-only" || policy.coverage.enforcement === "hard-block");
+
+  if (!enabledGatesValid || !applicableModesValid || !parallelismValid || !coverageValid) {
+    return {
+      id: "policy_config",
+      label: "Policy config",
+      status: "fail",
+      message: "Policy configuration is invalid for the current v1 contract.",
+      remediation: "Restore a valid gate, parallelism, and coverage policy configuration."
+    };
+  }
+
+  return {
+    id: "policy_config",
+    label: "Policy config",
+    status: "pass",
+    message: "Policy configuration is valid for the current v1 contract."
+  };
+}
+
+async function defaultCommandRunner(
+  command: string,
+  args: string[],
+  options?: { cwd?: string }
+): Promise<DoctorCommandResult> {
+  const result = await execFileAsync(command, args, {
+    encoding: "utf8",
+    ...(options?.cwd ? { cwd: options.cwd } : {})
+  });
+
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr ?? ""
+  };
+}

--- a/tests/cli/doctor-command.test.ts
+++ b/tests/cli/doctor-command.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { runCli } from "../../src/cli.js";
+import type { DoctorResult } from "../../src/core/diagnostics/doctor.js";
+
+function buildDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorResult {
+  return {
+    overall_status: "pass",
+    checks: [
+      {
+        id: "node_version",
+        label: "Node.js runtime",
+        status: "pass",
+        message: "Node.js 22.3.0 satisfies the minimum runtime requirement."
+      }
+    ],
+    summary: {
+      passed: 1,
+      failed: 0
+    },
+    ...overrides
+  };
+}
+
+describe("sf doctor command", () => {
+  it("writes the doctor report and exits cleanly on success", async () => {
+    let stdout = "";
+
+    const exitCode = await runCli(["node", "sf", "doctor"], {
+      stdout: {
+        write(chunk: string) {
+          stdout += chunk;
+          return true;
+        }
+      },
+      doctor_runner: async () => buildDoctorResult()
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("SpecForge Doctor");
+    expect(stdout).toContain("PASS node_version");
+  });
+
+  it("returns exit code 1 when doctor detects blocking failures", async () => {
+    const exitCode = await runCli(["node", "sf", "doctor"], {
+      stdout: {
+        write() {
+          return true;
+        }
+      },
+      doctor_runner: async () =>
+        buildDoctorResult({
+          overall_status: "fail",
+          checks: [
+            {
+              id: "git_binary",
+              label: "Git binary",
+              status: "fail",
+              message: "git was not found on PATH.",
+              remediation: "Install git and ensure it is available on PATH."
+            }
+          ],
+          summary: {
+            passed: 0,
+            failed: 1
+          }
+        })
+    });
+
+    expect(exitCode).toBe(1);
+  });
+});

--- a/tests/diagnostics/doctor.test.ts
+++ b/tests/diagnostics/doctor.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { createDefaultPolicyConfig } from "../../src/core/contracts/policy.js";
+import { formatDoctorReport, runDoctor, type DoctorCommandRunner } from "../../src/core/diagnostics/doctor.js";
+
+function createRunner(
+  responses: Record<string, { stdout?: string; stderr?: string; error?: Error }>
+): DoctorCommandRunner {
+  return async (command, args) => {
+    const key = `${command} ${args.join(" ")}`;
+    const response = responses[key];
+    if (!response) {
+      throw new Error(`Unexpected command: ${key}`);
+    }
+
+    if (response.error) {
+      throw response.error;
+    }
+
+    return {
+      stdout: response.stdout ?? "",
+      stderr: response.stderr ?? ""
+    };
+  };
+}
+
+describe("runDoctor failure paths", () => {
+  it("reports deterministic remediation when required tooling is missing", async () => {
+    const result = await runDoctor({
+      cwd: "/workspace/specforge",
+      node_version: "v20.11.1",
+      command_runner: createRunner({
+        "git --version": { error: new Error("git missing") },
+        "pnpm --version": { error: new Error("pnpm missing") }
+      })
+    });
+
+    expect(result.overall_status).toBe("fail");
+    expect(result.summary).toEqual({
+      passed: 1,
+      failed: 4
+    });
+    expect(result.checks).toEqual([
+      expect.objectContaining({
+        id: "node_version",
+        status: "fail",
+        remediation: "Install Node.js 22 LTS or newer and re-run sf doctor."
+      }),
+      expect.objectContaining({
+        id: "git_binary",
+        status: "fail",
+        remediation: "Install git and ensure it is available on PATH."
+      }),
+      expect.objectContaining({
+        id: "pnpm_binary",
+        status: "fail",
+        remediation: "Install pnpm and ensure it is available on PATH."
+      }),
+      expect.objectContaining({
+        id: "repository_root",
+        status: "fail",
+        remediation: "Initialize or open a git repository before running execution commands."
+      }),
+      expect.objectContaining({
+        id: "policy_config",
+        status: "pass"
+      })
+    ]);
+  });
+});
+
+describe("runDoctor success paths", () => {
+  it("passes environment, repository, and policy checks with stable report formatting", async () => {
+    const result = await runDoctor({
+      cwd: "/workspace/specforge",
+      node_version: "v22.3.0",
+      command_runner: createRunner({
+        "git --version": { stdout: "git version 2.47.0\n" },
+        "pnpm --version": { stdout: "10.31.0\n" },
+        "git rev-parse --show-toplevel": { stdout: "/workspace/specforge\n" }
+      }),
+      policy: createDefaultPolicyConfig()
+    });
+
+    expect(result.overall_status).toBe("pass");
+    expect(result.summary).toEqual({
+      passed: 5,
+      failed: 0
+    });
+
+    expect(formatDoctorReport(result)).toContain("SpecForge Doctor");
+    expect(formatDoctorReport(result)).toContain("PASS node_version");
+    expect(formatDoctorReport(result)).toContain("PASS repository_root");
+    expect(formatDoctorReport(result)).toContain("Summary: 5 passed, 0 failed");
+  });
+});


### PR DESCRIPTION
Closes #29

## Summary
- add deterministic doctor diagnostics for Node, git, pnpm, repository readiness, and policy validation
- wire sf doctor into the CLI with testable command execution and explicit exit codes
- cover doctor output and failure remediation with diagnostics and CLI tests