### PR TITLE
feat: implement sf explain command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,12 @@ import {
   type DoctorResult,
   type RunDoctorInput
 } from "./core/diagnostics/doctor.js";
+import {
+  formatExplainReport,
+  runExplain,
+  type ExplainResult,
+  type RunExplainInput
+} from "./core/diagnostics/explain.js";
 
 interface CliWriter {
   write(chunk: string): boolean | void;
@@ -17,6 +23,8 @@ export interface CliDependencies {
   stderr?: CliWriter;
   doctor_runner?: (input?: RunDoctorInput) => Promise<DoctorResult>;
   doctor_input?: RunDoctorInput;
+  explain_runner?: (input: RunExplainInput) => Promise<ExplainResult>;
+  explain_input?: Partial<RunExplainInput>;
 }
 
 class CliExitSignal extends Error {
@@ -31,9 +39,14 @@ class CliExitSignal extends Error {
 
 export function createProgram(dependencies: CliDependencies = {}): Command {
   const stdout = dependencies.stdout ?? process.stdout;
+  const stderr = dependencies.stderr ?? process.stderr;
   const doctorRunner = dependencies.doctor_runner ?? runDoctor;
   const doctorInput = dependencies.doctor_input;
+  const explainRunner = dependencies.explain_runner ?? runExplain;
+  const explainInput = dependencies.explain_input;
   const program = new Command();
+
+  program.exitOverride();
 
   program
     .name("specforge")
@@ -63,6 +76,33 @@ export function createProgram(dependencies: CliDependencies = {}): Command {
       }
     });
 
+  program
+    .command("explain")
+    .description("Render deterministic explanations grounded in artifact, policy, and scheduler evidence")
+    .option(
+      "--artifact-file <path>",
+      "Path to an artifact JSON file to explain",
+      collectOptionValues,
+      []
+    )
+    .option("--policy-file <path>", "Path to a policy JSON file")
+    .option("--schedule-file <path>", "Path to a scheduler JSON file")
+    .action(async (options: { artifactFile: string[]; policyFile?: string; scheduleFile?: string }) => {
+      try {
+        const result = await explainRunner({
+          artifact_files: options.artifactFile,
+          ...(options.policyFile ? { policy_file: options.policyFile } : {}),
+          ...(options.scheduleFile ? { schedule_file: options.scheduleFile } : {}),
+          ...(explainInput ?? {})
+        });
+
+        stdout.write(formatExplainReport(result));
+      } catch (error) {
+        stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+        throw new CliExitSignal(1);
+      }
+    });
+
   return program;
 }
 
@@ -77,20 +117,24 @@ export async function runCli(argv: string[] = process.argv, dependencies: CliDep
       return error.exitCode;
     }
 
-    throw error;
+    if (error instanceof Error) {
+      (dependencies.stderr ?? process.stderr).write(`${error.message}\n`);
+      return 1;
+    }
+
+    (dependencies.stderr ?? process.stderr).write(`${String(error)}\n`);
+    return 1;
   }
 }
 
 async function main(): Promise<void> {
-  try {
-    process.exitCode = await runCli(process.argv);
-  } catch (error) {
-    const stderr = process.stderr;
-    stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    process.exitCode = 1;
-  }
+  process.exitCode = await runCli(process.argv);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   void main();
+}
+
+function collectOptionValues(value: string, previous: string[]): string[] {
+  return [...previous, value];
 }

--- a/src/core/diagnostics/explain.ts
+++ b/src/core/diagnostics/explain.ts
@@ -1,0 +1,345 @@
+import { readFile } from "node:fs/promises";
+
+import { ARTIFACT_GATES } from "../contracts/domain.js";
+import type { SpecForgePolicyConfig } from "../contracts/policy.js";
+import type { ConservativeSchedule, ConservativeScheduleBatch } from "../execution/scheduler.js";
+
+export type ExplainErrorCode =
+  | "missing_artifact_input"
+  | "artifact_read_failed"
+  | "invalid_artifact"
+  | "policy_read_failed"
+  | "invalid_policy"
+  | "schedule_read_failed"
+  | "invalid_schedule";
+
+export class ExplainError extends Error {
+  readonly code: ExplainErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: ExplainErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "ExplainError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface ExplainArtifactEvidence {
+  path: string;
+  kind?: string;
+  artifact_id: string;
+  artifact_version: string;
+  generator: string;
+  created_timestamp: string;
+  source_refs: Array<{
+    artifact_id: string;
+    artifact_version: string;
+  }>;
+}
+
+export interface ExplainPolicyEvidence {
+  source: string;
+  coverage: SpecForgePolicyConfig["coverage"];
+  parallelism: SpecForgePolicyConfig["parallelism"];
+  enabled_gates: string[];
+  disabled_gates: string[];
+}
+
+export interface ExplainScheduleEvidence {
+  source: string;
+  policy: ConservativeSchedule["policy"];
+  batches: ConservativeScheduleBatch[];
+}
+
+export interface ExplainResult {
+  artifacts: ExplainArtifactEvidence[];
+  policy?: ExplainPolicyEvidence;
+  schedule?: ExplainScheduleEvidence;
+}
+
+export interface RunExplainInput {
+  artifact_files: string[];
+  policy_file?: string;
+  schedule_file?: string;
+}
+
+/**
+ * Build an evidence-backed explanation from explicit artifact and policy inputs.
+ *
+ * This slice intentionally explains only what can be proven from the supplied files.
+ * It does not infer hidden run state or speculate about decisions that are not present
+ * in artifact metadata, policy config, or scheduler output.
+ */
+export async function runExplain(input: RunExplainInput): Promise<ExplainResult> {
+  const artifactFiles = normalizeArtifactFiles(input.artifact_files);
+  if (artifactFiles.length === 0) {
+    throw new ExplainError(
+      "missing_artifact_input",
+      "At least one --artifact-file input is required for sf explain."
+    );
+  }
+
+  const artifacts = await Promise.all(artifactFiles.map((path) => readArtifactEvidence(path)));
+  const policy = input.policy_file ? await readPolicyEvidence(input.policy_file) : undefined;
+  const schedule = input.schedule_file ? await readScheduleEvidence(input.schedule_file) : undefined;
+
+  return {
+    artifacts,
+    ...(policy ? { policy } : {}),
+    ...(schedule ? { schedule } : {})
+  };
+}
+
+export function formatExplainReport(result: ExplainResult): string {
+  const lines = ["SpecForge Explain", ""];
+
+  lines.push("Artifacts");
+  for (const artifact of result.artifacts) {
+    lines.push(`- ${artifact.artifact_id} (${artifact.artifact_version})`);
+    lines.push(`  path: ${artifact.path}`);
+    lines.push(`  generator: ${artifact.generator}`);
+    lines.push(`  created: ${artifact.created_timestamp}`);
+    if (artifact.kind) {
+      lines.push(`  kind: ${artifact.kind}`);
+    }
+    if (artifact.source_refs.length === 0) {
+      lines.push("  source_refs: none");
+    } else {
+      lines.push(
+        `  source_refs: ${artifact.source_refs
+          .map((sourceRef) => `${sourceRef.artifact_id}@${sourceRef.artifact_version}`)
+          .join(", ")}`
+      );
+    }
+  }
+
+  if (result.policy) {
+    lines.push("");
+    lines.push("Policy");
+    lines.push(`- source: ${result.policy.source}`);
+    lines.push(`  max_concurrent_tasks: ${result.policy.parallelism.max_concurrent_tasks}`);
+    lines.push(
+      `  serialize_on_uncertainty: ${result.policy.parallelism.serialize_on_uncertainty}`
+    );
+    lines.push(`  coverage_scope: ${result.policy.coverage.scope}`);
+    lines.push(`  coverage_enforcement: ${result.policy.coverage.enforcement}`);
+    lines.push(
+      `  enabled_gates: ${
+        result.policy.enabled_gates.length > 0 ? result.policy.enabled_gates.join(", ") : "none"
+      }`
+    );
+    lines.push(
+      `  disabled_gates: ${
+        result.policy.disabled_gates.length > 0 ? result.policy.disabled_gates.join(", ") : "none"
+      }`
+    );
+  }
+
+  if (result.schedule) {
+    lines.push("");
+    lines.push("Scheduler Evidence");
+    lines.push(`- source: ${result.schedule.source}`);
+    for (const batch of result.schedule.batches) {
+      lines.push(
+        `  ${batch.batch_id}: ${batch.execution_mode} -> ${batch.task_ids.join(", ")} (${batch.reasons.join(", ")})`
+      );
+    }
+  }
+
+  lines.push("");
+  lines.push("Reasoning");
+  for (const artifact of result.artifacts) {
+    lines.push(
+      `- ${artifact.artifact_id}@${artifact.artifact_version} was produced by ${artifact.generator} from ${artifact.source_refs.length} source reference(s).`
+    );
+  }
+
+  if (result.policy) {
+    lines.push(
+      `- Policy evidence shows max_concurrent_tasks=${result.policy.parallelism.max_concurrent_tasks} and serialize_on_uncertainty=${result.policy.parallelism.serialize_on_uncertainty}.`
+    );
+  }
+
+  if (result.schedule) {
+    for (const batch of result.schedule.batches) {
+      lines.push(
+        `- Scheduler batch ${batch.batch_id} is ${batch.execution_mode} because of ${batch.reasons.join(", ")}.`
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function normalizeArtifactFiles(artifactFiles: string[]): string[] {
+  return [...new Set(artifactFiles.map((path) => path.trim()).filter((path) => path.length > 0))];
+}
+
+async function readArtifactEvidence(path: string): Promise<ExplainArtifactEvidence> {
+  const value = await readJsonFile(path, "artifact_read_failed");
+  const artifact = asArtifactEvidenceInput(value, path);
+
+  return {
+    path,
+    ...(typeof artifact.kind === "string" ? { kind: artifact.kind } : {}),
+    artifact_id: artifact.metadata.artifact_id,
+    artifact_version: artifact.metadata.artifact_version,
+    generator: artifact.metadata.generator,
+    created_timestamp: artifact.metadata.created_timestamp,
+    source_refs: artifact.metadata.source_refs.map((sourceRef) => ({
+      artifact_id: sourceRef.artifact_id,
+      artifact_version: sourceRef.artifact_version
+    }))
+  };
+}
+
+async function readPolicyEvidence(path: string): Promise<ExplainPolicyEvidence> {
+  const value = await readJsonFile(path, "policy_read_failed");
+  if (!isPolicyConfig(value)) {
+    throw new ExplainError("invalid_policy", `Invalid policy file: ${path}`);
+  }
+
+  const enabledGates = ARTIFACT_GATES.filter((gate) => value.gates.enabled_by_default[gate] === true);
+  const disabledGates = ARTIFACT_GATES.filter((gate) => value.gates.enabled_by_default[gate] === false);
+
+  return {
+    source: path,
+    coverage: value.coverage,
+    parallelism: value.parallelism,
+    enabled_gates: enabledGates,
+    disabled_gates: disabledGates
+  };
+}
+
+async function readScheduleEvidence(path: string): Promise<ExplainScheduleEvidence> {
+  const value = await readJsonFile(path, "schedule_read_failed");
+  if (!isConservativeSchedule(value)) {
+    throw new ExplainError("invalid_schedule", `Invalid schedule file: ${path}`);
+  }
+
+  return {
+    source: path,
+    policy: value.policy,
+    batches: value.batches
+  };
+}
+
+async function readJsonFile(path: string, errorCode: ExplainErrorCode): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch (error) {
+    throw new ExplainError(errorCode, `Failed to read JSON file: ${path}`, error);
+  }
+}
+
+function asArtifactEvidenceInput(
+  value: unknown,
+  path: string
+): {
+  kind?: unknown;
+  metadata: {
+    artifact_id: string;
+    artifact_version: string;
+    generator: string;
+    created_timestamp: string;
+    source_refs: Array<{ artifact_id: string; artifact_version: string }>;
+  };
+} {
+  if (!value || typeof value !== "object") {
+    throw new ExplainError("invalid_artifact", `Artifact file must contain an object: ${path}`);
+  }
+
+  const candidate = value as {
+    kind?: unknown;
+    metadata?: {
+      artifact_id?: unknown;
+      artifact_version?: unknown;
+      generator?: unknown;
+      created_timestamp?: unknown;
+      source_refs?: Array<{ artifact_id?: unknown; artifact_version?: unknown }>;
+    };
+  };
+
+  if (
+    !candidate.metadata ||
+    typeof candidate.metadata.artifact_id !== "string" ||
+    typeof candidate.metadata.artifact_version !== "string" ||
+    typeof candidate.metadata.generator !== "string" ||
+    typeof candidate.metadata.created_timestamp !== "string" ||
+    !Array.isArray(candidate.metadata.source_refs)
+  ) {
+    throw new ExplainError(
+      "invalid_artifact",
+      `Artifact file is missing required metadata fields: ${path}`
+    );
+  }
+
+  for (const sourceRef of candidate.metadata.source_refs) {
+    if (
+      !sourceRef ||
+      typeof sourceRef.artifact_id !== "string" ||
+      typeof sourceRef.artifact_version !== "string"
+    ) {
+      throw new ExplainError(
+        "invalid_artifact",
+        `Artifact file contains an invalid source_ref entry: ${path}`
+      );
+    }
+  }
+
+  return {
+    kind: candidate.kind,
+    metadata: {
+      artifact_id: candidate.metadata.artifact_id,
+      artifact_version: candidate.metadata.artifact_version,
+      generator: candidate.metadata.generator,
+      created_timestamp: candidate.metadata.created_timestamp,
+      source_refs: candidate.metadata.source_refs as Array<{
+        artifact_id: string;
+        artifact_version: string;
+      }>
+    }
+  };
+}
+
+function isPolicyConfig(value: unknown): value is SpecForgePolicyConfig {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<SpecForgePolicyConfig>;
+  return (
+    !!candidate.coverage &&
+    !!candidate.parallelism &&
+    !!candidate.gates &&
+    typeof candidate.coverage.scope === "string" &&
+    typeof candidate.coverage.enforcement === "string" &&
+    typeof candidate.parallelism.max_concurrent_tasks === "number" &&
+    typeof candidate.parallelism.serialize_on_uncertainty === "boolean" &&
+    !!candidate.gates.enabled_by_default &&
+    typeof candidate.gates.enabled_by_default === "object"
+  );
+}
+
+function isConservativeSchedule(value: unknown): value is ConservativeSchedule {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<ConservativeSchedule>;
+  return (
+    !!candidate.policy &&
+    typeof candidate.policy.max_concurrent_tasks === "number" &&
+    typeof candidate.policy.serialize_on_uncertainty === "boolean" &&
+    Array.isArray(candidate.batches) &&
+    candidate.batches.every(
+      (batch) =>
+        batch &&
+        typeof batch.batch_id === "string" &&
+        (batch.execution_mode === "serial" || batch.execution_mode === "parallel") &&
+        Array.isArray(batch.task_ids) &&
+        Array.isArray(batch.reasons)
+    )
+  );
+}

--- a/tests/cli/explain-command.test.ts
+++ b/tests/cli/explain-command.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { runCli } from "../../src/cli.js";
+import type { ExplainResult } from "../../src/core/diagnostics/explain.js";
+
+function buildExplainResult(overrides: Partial<ExplainResult> = {}): ExplainResult {
+  return {
+    artifacts: [
+      {
+        path: "/workspace/.specforge/task-results/TASK-1.json",
+        artifact_id: "task_execution_result.task-1",
+        artifact_version: "v2",
+        generator: "operation.devTDDTask",
+        created_timestamp: "2026-03-12T23:30:00.000Z",
+        source_refs: [
+          {
+            artifact_id: "context_pack.task-1",
+            artifact_version: "v4"
+          }
+        ]
+      }
+    ],
+    ...overrides
+  };
+}
+
+describe("sf explain command", () => {
+  it("writes the explain report and exits cleanly on success", async () => {
+    let stdout = "";
+
+    const exitCode = await runCli(["node", "sf", "explain", "--artifact-file", "artifact.json"], {
+      stdout: {
+        write(chunk: string) {
+          stdout += chunk;
+          return true;
+        }
+      },
+      explain_runner: async () => buildExplainResult()
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("SpecForge Explain");
+    expect(stdout).toContain("task_execution_result.task-1");
+  });
+
+  it("returns exit code 1 when explain fails validation", async () => {
+    let stderr = "";
+
+    const exitCode = await runCli(["node", "sf", "explain"], {
+      stderr: {
+        write(chunk: string) {
+          stderr += chunk;
+          return true;
+        }
+      },
+      explain_runner: async () => {
+        throw new Error("missing artifact");
+      }
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("missing artifact");
+  });
+});

--- a/tests/diagnostics/explain.test.ts
+++ b/tests/diagnostics/explain.test.ts
@@ -1,0 +1,141 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import { createDefaultPolicyConfig } from "../../src/core/contracts/policy.js";
+import {
+  ExplainError,
+  formatExplainReport,
+  runExplain
+} from "../../src/core/diagnostics/explain.js";
+import type { ConservativeSchedule } from "../../src/core/execution/scheduler.js";
+
+async function writeJsonFile(dir: string, name: string, value: unknown): Promise<string> {
+  const filePath = join(dir, name);
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  return filePath;
+}
+
+function buildArtifact() {
+  return {
+    kind: "task_execution_result",
+    metadata: {
+      artifact_id: "task_execution_result.task-1",
+      artifact_version: "v2",
+      parent_version: "v1",
+      created_timestamp: "2026-03-12T23:30:00.000Z",
+      generator: "operation.devTDDTask",
+      source_refs: [
+        {
+          artifact_id: "context_pack.task-1",
+          artifact_version: "v4"
+        }
+      ],
+      checksum: "a".repeat(64)
+    },
+    task_id: "TASK-1",
+    status: "completed"
+  };
+}
+
+function buildSchedule(): ConservativeSchedule {
+  return {
+    policy: {
+      max_concurrent_tasks: 2,
+      serialize_on_uncertainty: true
+    },
+    batches: [
+      {
+        batch_id: "batch-1",
+        execution_mode: "serial",
+        task_ids: ["TASK-1"],
+        reasons: ["uncertain_touch_set"]
+      }
+    ]
+  };
+}
+
+describe("runExplain failure paths", () => {
+  it("fails with a typed error when no artifact files are provided", async () => {
+    await expect(
+      runExplain({
+        artifact_files: []
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<ExplainError>>({
+        code: "missing_artifact_input"
+      })
+    );
+  });
+
+  it("fails with a typed error when an artifact file is missing metadata", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "specforge-explain-"));
+    const artifactFile = await writeJsonFile(tempDir, "broken-artifact.json", {
+      kind: "task_execution_result"
+    });
+
+    await expect(
+      runExplain({
+        artifact_files: [artifactFile]
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<ExplainError>>({
+        code: "invalid_artifact"
+      })
+    );
+  });
+});
+
+describe("runExplain success paths", () => {
+  it("renders deterministic evidence grounded in artifact, policy, and scheduler files", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "specforge-explain-"));
+    const artifactFile = await writeJsonFile(tempDir, "task_execution_result.json", buildArtifact());
+    const policyFile = await writeJsonFile(tempDir, "policy.json", createDefaultPolicyConfig());
+    const scheduleFile = await writeJsonFile(tempDir, "schedule.json", buildSchedule());
+
+    const result = await runExplain({
+      artifact_files: [artifactFile],
+      policy_file: policyFile,
+      schedule_file: scheduleFile
+    });
+
+    expect(result.artifacts).toEqual([
+      expect.objectContaining({
+        path: artifactFile,
+        artifact_id: "task_execution_result.task-1",
+        artifact_version: "v2",
+        generator: "operation.devTDDTask"
+      })
+    ]);
+    expect(result.policy).toEqual(
+      expect.objectContaining({
+        source: policyFile,
+        parallelism: {
+          max_concurrent_tasks: 2,
+          serialize_on_uncertainty: true
+        }
+      })
+    );
+    expect(result.schedule).toEqual(
+      expect.objectContaining({
+        source: scheduleFile,
+        batches: [
+          expect.objectContaining({
+            batch_id: "batch-1",
+            reasons: ["uncertain_touch_set"]
+          })
+        ]
+      })
+    );
+
+    const report = formatExplainReport(result);
+    expect(report).toContain("SpecForge Explain");
+    expect(report).toContain("task_execution_result.task-1");
+    expect(report).toContain("generator: operation.devTDDTask");
+    expect(report).toContain("batch-1");
+    expect(report).toContain("uncertain_touch_set");
+    expect(report).toContain("max_concurrent_tasks: 2");
+  });
+});


### PR DESCRIPTION
Closes #30

## Summary
- add deterministic explain diagnostics grounded in artifact, policy, and scheduler files
- wire sf explain into the CLI with explicit error handling and stable report formatting
- cover explain diagnostics and CLI behavior with tests