### PR TITLE
feat: implement sf inspect command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,12 @@ import {
   type ExplainResult,
   type RunExplainInput
 } from "./core/diagnostics/explain.js";
+import {
+  formatInspectReport,
+  runInspect,
+  type InspectResult,
+  type RunInspectInput
+} from "./core/diagnostics/inspect.js";
 
 interface CliWriter {
   write(chunk: string): boolean | void;
@@ -25,6 +31,8 @@ export interface CliDependencies {
   doctor_input?: RunDoctorInput;
   explain_runner?: (input: RunExplainInput) => Promise<ExplainResult>;
   explain_input?: Partial<RunExplainInput>;
+  inspect_runner?: (input?: RunInspectInput) => Promise<InspectResult>;
+  inspect_input?: Partial<RunInspectInput>;
 }
 
 class CliExitSignal extends Error {
@@ -44,6 +52,8 @@ export function createProgram(dependencies: CliDependencies = {}): Command {
   const doctorInput = dependencies.doctor_input;
   const explainRunner = dependencies.explain_runner ?? runExplain;
   const explainInput = dependencies.explain_input;
+  const inspectRunner = dependencies.inspect_runner ?? runInspect;
+  const inspectInput = dependencies.inspect_input;
   const program = new Command();
 
   program.exitOverride();
@@ -102,6 +112,30 @@ export function createProgram(dependencies: CliDependencies = {}): Command {
         throw new CliExitSignal(1);
       }
     });
+
+  program
+    .command("inspect")
+    .description("Profile the repository and map bounded architecture outputs without touching application code")
+    .option("--repository-root <path>", "Repository root to inspect")
+    .option("--artifact-dir <path>", "Directory where .specforge artifacts should be written")
+    .option("--deep", "Increase the bounded scan budget for deeper repository inspection")
+    .action(
+      async (options: { repositoryRoot?: string; artifactDir?: string; deep?: boolean }) => {
+        try {
+          const result = await inspectRunner({
+            repository_root: options.repositoryRoot ?? process.cwd(),
+            ...(options.artifactDir ? { artifact_dir: options.artifactDir } : {}),
+            ...(options.deep ? { deep: true } : {}),
+            ...(inspectInput ?? {})
+          });
+
+          stdout.write(formatInspectReport(result));
+        } catch (error) {
+          stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+          throw new CliExitSignal(1);
+        }
+      }
+    );
 
   return program;
 }

--- a/src/core/diagnostics/inspect.ts
+++ b/src/core/diagnostics/inspect.ts
@@ -1,0 +1,150 @@
+import { join } from "node:path";
+
+import type { ArchitectureSummaryArtifact } from "../operations/mapArchitectureFromRepo.js";
+import {
+  MapArchitectureFromRepoError,
+  runMapArchitectureFromRepo,
+  type MapArchitectureFromRepoInput
+} from "../operations/mapArchitectureFromRepo.js";
+import type { RepoProfileArtifact } from "../operations/profileRepository.js";
+import {
+  ProfileRepositoryError,
+  runProfileRepository,
+  type ProfileRepositoryInput
+} from "../operations/profileRepository.js";
+
+const STANDARD_MAX_FILES = 200;
+const DEEP_MAX_FILES = 1000;
+
+export type InspectScanMode = "standard" | "deep";
+export type InspectErrorCode = "profile_failed" | "architecture_failed";
+
+export class InspectError extends Error {
+  readonly code: InspectErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: InspectErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "InspectError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface InspectResult {
+  scan_mode: InspectScanMode;
+  repository_root: string;
+  repo_profile_path: string;
+  architecture_summary_path: string;
+  repo_profile: RepoProfileArtifact;
+  architecture_summary: ArchitectureSummaryArtifact;
+}
+
+export interface RunInspectInput {
+  repository_root?: string;
+  artifact_dir?: string;
+  deep?: boolean;
+  created_timestamp?: Date;
+  profile_runner?: (input: ProfileRepositoryInput) => Promise<{ repo_profile: RepoProfileArtifact }>;
+  architecture_runner?: (
+    input: MapArchitectureFromRepoInput
+  ) => Promise<{ architecture_summary: ArchitectureSummaryArtifact }>;
+}
+
+/**
+ * Produce repository inspection artifacts without modifying application code.
+ *
+ * This orchestration layer intentionally composes the existing bounded repository
+ * profiling and architecture mapping operations. The only files written are the
+ * published artifacts under .specforge for the inspected repository.
+ */
+export async function runInspect(input: RunInspectInput = {}): Promise<InspectResult> {
+  const repositoryRoot = input.repository_root ?? process.cwd();
+  const artifactRoot = input.artifact_dir ?? repositoryRoot;
+  const profileArtifactDir = input.artifact_dir ? join(input.artifact_dir, ".specforge") : undefined;
+  const scanMode: InspectScanMode = input.deep === true ? "deep" : "standard";
+  const maxFiles = scanMode === "deep" ? DEEP_MAX_FILES : STANDARD_MAX_FILES;
+  const profileRunner = input.profile_runner ?? runProfileRepository;
+  const architectureRunner = input.architecture_runner ?? runMapArchitectureFromRepo;
+
+  let repoProfile: RepoProfileArtifact;
+  try {
+    const result = await profileRunner({
+      project_mode: "existing-repo",
+      repository_root: repositoryRoot,
+      ...(profileArtifactDir ? { artifact_dir: profileArtifactDir } : {}),
+      max_files: maxFiles,
+      ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+    });
+    repoProfile = result.repo_profile;
+  } catch (error) {
+    if (error instanceof ProfileRepositoryError) {
+      throw new InspectError(
+        "profile_failed",
+        `Repository profiling failed: ${error.message}`,
+        error
+      );
+    }
+
+    throw error;
+  }
+
+  let architectureSummary: ArchitectureSummaryArtifact;
+  try {
+    const result = await architectureRunner({
+      project_mode: "existing-repo",
+      repo_profile: repoProfile,
+      artifact_dir: artifactRoot,
+      ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
+    });
+    architectureSummary = result.architecture_summary;
+  } catch (error) {
+    if (error instanceof MapArchitectureFromRepoError) {
+      throw new InspectError(
+        "architecture_failed",
+        `Architecture mapping failed: ${error.message}`,
+        error
+      );
+    }
+
+    throw error;
+  }
+
+  return {
+    scan_mode: scanMode,
+    repository_root: repositoryRoot,
+    repo_profile_path: join(artifactRoot, ".specforge", "repo_profile.json"),
+    architecture_summary_path: join(artifactRoot, ".specforge", "architecture_summary.json"),
+    repo_profile: repoProfile,
+    architecture_summary: architectureSummary
+  };
+}
+
+export function formatInspectReport(result: InspectResult): string {
+  const lines = [
+    "SpecForge Inspect",
+    "",
+    `Repository Root: ${result.repository_root}`,
+    `Scan Mode: ${result.scan_mode}`,
+    `Repo Profile: ${result.repo_profile.metadata.artifact_id}@${result.repo_profile.metadata.artifact_version}`,
+    `Architecture Summary: ${result.architecture_summary.metadata.artifact_id}@${result.architecture_summary.metadata.artifact_version}`,
+    `Repo Profile Path: ${result.repo_profile_path}`,
+    `Architecture Summary Path: ${result.architecture_summary_path}`,
+    "",
+    "Repo Profile Evidence",
+    `- scanned_file_count: ${result.repo_profile.scan.scanned_file_count}`,
+    `- max_files: ${result.repo_profile.scan.max_files}`,
+    `- truncated: ${result.repo_profile.scan.truncated}`,
+    `- detected_tooling: ${result.repo_profile.evidence.detected_tooling.join(", ") || "none"}`,
+    "",
+    "Architecture Subsystems"
+  ];
+
+  for (const subsystem of result.architecture_summary.subsystems) {
+    lines.push(
+      `- ${subsystem.id} (${subsystem.file_count} files, ${subsystem.uncertainty} uncertainty)`
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/tests/cli/inspect-command.test.ts
+++ b/tests/cli/inspect-command.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { runCli } from "../../src/cli.js";
+import type { InspectResult } from "../../src/core/diagnostics/inspect.js";
+
+function buildInspectResult(overrides: Partial<InspectResult> = {}): InspectResult {
+  return {
+    scan_mode: "standard",
+    repository_root: "/workspace/specforge",
+    repo_profile_path: "/workspace/specforge/.specforge/repo_profile.json",
+    architecture_summary_path: "/workspace/specforge/.specforge/architecture_summary.json",
+    repo_profile: {
+      kind: "repo_profile",
+      metadata: {
+        artifact_id: "repo_profile",
+        artifact_version: "v1",
+        created_timestamp: "2026-03-13T23:59:00.000Z",
+        generator: "operation.profileRepository",
+        source_refs: [],
+        checksum: "a".repeat(64)
+      },
+      project_mode: "existing-repo",
+      repository_root: "/workspace/specforge",
+      scan: {
+        max_files: 200,
+        scanned_file_count: 3,
+        truncated: false,
+        ignored_directories: [".git", ".specforge"]
+      },
+      evidence: {
+        top_level_entries: ["README.md", "src"],
+        sampled_files: ["src/api/routes.ts", "src/api/service.ts", "src/cli/main.ts"],
+        extension_counts: [{ extension: ".ts", count: 3 }],
+        detected_manifests: ["package.json"],
+        detected_tooling: ["node", "typescript"]
+      }
+    },
+    architecture_summary: {
+      kind: "architecture_summary",
+      metadata: {
+        artifact_id: "architecture_summary",
+        artifact_version: "v1",
+        created_timestamp: "2026-03-13T23:59:01.000Z",
+        generator: "operation.mapArchitectureFromRepo",
+        source_refs: [{ artifact_id: "repo_profile", artifact_version: "v1" }],
+        checksum: "b".repeat(64)
+      },
+      project_mode: "existing-repo",
+      repository_root: "/workspace/specforge",
+      subsystems: [
+        {
+          id: "src/api",
+          label: "src/api",
+          inferred_responsibility: "API/backend surface",
+          file_count: 2,
+          evidence_refs: ["src/api/routes.ts", "src/api/service.ts"],
+          uncertainty: "low"
+        }
+      ],
+      summary_markdown: "# Architecture Summary"
+    },
+    ...overrides
+  };
+}
+
+describe("sf inspect command", () => {
+  it("writes the inspect report and exits cleanly on success", async () => {
+    let stdout = "";
+
+    const exitCode = await runCli(["node", "sf", "inspect"], {
+      stdout: {
+        write(chunk: string) {
+          stdout += chunk;
+          return true;
+        }
+      },
+      inspect_runner: async () => buildInspectResult()
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("SpecForge Inspect");
+    expect(stdout).toContain("repo_profile@v1");
+    expect(stdout).toContain("src/api");
+  });
+
+  it("returns exit code 1 when inspect fails", async () => {
+    let stderr = "";
+
+    const exitCode = await runCli(["node", "sf", "inspect"], {
+      stderr: {
+        write(chunk: string) {
+          stderr += chunk;
+          return true;
+        }
+      },
+      inspect_runner: async () => {
+        throw new Error("inspect failed");
+      }
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("inspect failed");
+  });
+});

--- a/tests/diagnostics/inspect.test.ts
+++ b/tests/diagnostics/inspect.test.ts
@@ -1,0 +1,119 @@
+import { mkdtemp, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  InspectError,
+  formatInspectReport,
+  runInspect
+} from "../../src/core/diagnostics/inspect.js";
+
+interface RepoFile {
+  path: string;
+  content: string;
+}
+
+async function writeRepoFiles(root: string, files: RepoFile[]): Promise<void> {
+  for (const file of files) {
+    const absolutePath = join(root, file.path);
+    await mkdir(join(absolutePath, ".."), { recursive: true });
+    await writeFile(absolutePath, file.content, "utf8");
+  }
+}
+
+describe("runInspect failure paths", () => {
+  it("fails with a typed error when repository profiling fails", async () => {
+    const missingRoot = join(tmpdir(), "specforge-inspect-missing", String(Date.now()));
+
+    await expect(
+      runInspect({
+        repository_root: missingRoot
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<InspectError>>({
+        code: "profile_failed"
+      })
+    );
+  });
+});
+
+describe("runInspect success paths", () => {
+  it("produces repo profile and architecture artifacts without modifying application files", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "specforge-inspect-"));
+
+    await writeRepoFiles(repoRoot, [
+      { path: "package.json", content: "{\"name\":\"demo\"}" },
+      { path: "tsconfig.json", content: "{\"compilerOptions\":{}}" },
+      { path: "src/api/routes.ts", content: "export const routes = [];" },
+      { path: "src/api/service.ts", content: "export const service = {};" },
+      { path: "src/cli/main.ts", content: "export const main = () => {};" },
+      { path: "README.md", content: "# Demo\n" }
+    ]);
+
+    const originalReadme = await readFile(join(repoRoot, "README.md"), "utf8");
+    const result = await runInspect({
+      repository_root: repoRoot,
+      created_timestamp: new Date("2026-03-13T23:59:00.000Z")
+    });
+
+    expect(result.repo_profile.kind).toBe("repo_profile");
+    expect(result.architecture_summary.kind).toBe("architecture_summary");
+    expect(result.repo_profile.metadata.generator).toBe("operation.profileRepository");
+    expect(result.architecture_summary.metadata.generator).toBe(
+      "operation.mapArchitectureFromRepo"
+    );
+    expect(result.repo_profile_path).toBe(join(repoRoot, ".specforge", "repo_profile.json"));
+    expect(result.architecture_summary_path).toBe(
+      join(repoRoot, ".specforge", "architecture_summary.json")
+    );
+    expect(result.architecture_summary.subsystems.map((subsystem) => subsystem.id)).toEqual([
+      "src/api",
+      "src/cli"
+    ]);
+
+    expect(await readFile(join(repoRoot, "README.md"), "utf8")).toBe(originalReadme);
+    expect((await readdir(repoRoot)).sort((left, right) => left.localeCompare(right))).toEqual([
+      ".specforge",
+      "package.json",
+      "README.md",
+      "src",
+      "tsconfig.json"
+    ]);
+
+    const report = formatInspectReport(result);
+    expect(report).toContain("SpecForge Inspect");
+    expect(report).toContain("repo_profile@v1");
+    expect(report).toContain("architecture_summary@v1");
+    expect(report).toContain("src/api");
+  });
+
+  it("supports bounded deep inspection by increasing the scan budget", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "specforge-inspect-"));
+
+    await writeRepoFiles(
+      repoRoot,
+      Array.from({ length: 250 }, (_, index) => ({
+        path: `src/file-${index.toString().padStart(3, "0")}.ts`,
+        content: `export const value${index} = ${index};\n`
+      }))
+    );
+
+    const standard = await runInspect({
+      repository_root: repoRoot
+    });
+    const deep = await runInspect({
+      repository_root: repoRoot,
+      deep: true
+    });
+
+    expect(standard.scan_mode).toBe("standard");
+    expect(standard.repo_profile.scan.max_files).toBe(200);
+    expect(standard.repo_profile.scan.truncated).toBe(true);
+
+    expect(deep.scan_mode).toBe("deep");
+    expect(deep.repo_profile.scan.max_files).toBe(1000);
+    expect(deep.repo_profile.scan.truncated).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #31

## Summary
- add deterministic inspect orchestration on top of repository profiling and architecture mapping
- wire sf inspect into the CLI with non-destructive bounded deep scan support
- cover inspect diagnostics and CLI behavior with tests