### PR TITLE
feat: add ci quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run typecheck
+        run: pnpm typecheck
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run build
+        run: pnpm build
+
+  policy:
+    name: policy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run CI policy check
+        run: pnpm ci:policy
+
+      - name: Upload CI policy report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-policy-report
+          path: .specforge/ci/policy-report.txt
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SpecForge
 
+[![CI](https://github.com/iKwesi/SpecForge/actions/workflows/ci.yml/badge.svg)](https://github.com/iKwesi/SpecForge/actions/workflows/ci.yml)
+
 SpecForge is a specification-driven engineering orchestration CLI that converts ideas and repository changes into disciplined, artifact-driven development workflows.
 
 SpecForge treats software engineering like a deterministic build system: ideas become specs, specs become tasks, and tasks become tested, reviewable changes.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "ci:policy": "tsx scripts/run-ci-policy-check.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/run-ci-policy-check.ts
+++ b/scripts/run-ci-policy-check.ts
@@ -1,0 +1,31 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { createDefaultPolicyConfig } from "../src/core/contracts/policy.js";
+import {
+  formatCiPolicyReport,
+  runCiPolicyCheck
+} from "../src/core/diagnostics/ciPolicy.js";
+
+async function main(): Promise<void> {
+  const result = runCiPolicyCheck(createDefaultPolicyConfig());
+  const report = formatCiPolicyReport(result);
+
+  process.stdout.write(report);
+  await writeReport(report);
+
+  if (result.overall_status === "fail") {
+    process.exitCode = 1;
+  }
+}
+
+async function writeReport(report: string): Promise<void> {
+  const outputDir = join(process.cwd(), ".specforge", "ci");
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(join(outputDir, "policy-report.txt"), report, "utf8");
+}
+
+void main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/core/diagnostics/ciPolicy.ts
+++ b/src/core/diagnostics/ciPolicy.ts
@@ -1,0 +1,133 @@
+import { ARTIFACT_GATES, PROJECT_MODES } from "../contracts/domain.js";
+import type { SpecForgePolicyConfig } from "../contracts/policy.js";
+
+export type CiPolicyStatus = "pass" | "fail";
+
+export interface CiPolicyCheck {
+  id: string;
+  status: CiPolicyStatus;
+  message: string;
+  remediation?: string;
+}
+
+export interface CiPolicyCheckSummary {
+  passed: number;
+  failed: number;
+}
+
+export interface CiPolicyCheckResult {
+  overall_status: CiPolicyStatus;
+  checks: CiPolicyCheck[];
+  summary: CiPolicyCheckSummary;
+}
+
+/**
+ * Validate the default engine policy against the bootstrap CI contract.
+ *
+ * CI should fail only when policy shape drifts from the supported v1 invariants,
+ * not because the checker invents new enforcement rules beyond the current contract.
+ */
+export function runCiPolicyCheck(policy: SpecForgePolicyConfig): CiPolicyCheckResult {
+  const checks: CiPolicyCheck[] = [
+    validateCoveragePolicy(policy),
+    validateParallelismPolicy(policy),
+    validateGatePolicy(policy)
+  ];
+
+  const summary = {
+    passed: checks.filter((check) => check.status === "pass").length,
+    failed: checks.filter((check) => check.status === "fail").length
+  };
+
+  return {
+    overall_status: summary.failed > 0 ? "fail" : "pass",
+    checks,
+    summary
+  };
+}
+
+export function formatCiPolicyReport(result: CiPolicyCheckResult): string {
+  const lines = ["SpecForge CI Policy Check", ""];
+
+  for (const check of result.checks) {
+    lines.push(`${check.status === "pass" ? "PASS" : "FAIL"} ${check.id} - ${check.message}`);
+    if (check.remediation) {
+      lines.push(`  Remediation: ${check.remediation}`);
+    }
+  }
+
+  lines.push("");
+  lines.push(`Summary: ${result.summary.passed} passed, ${result.summary.failed} failed`);
+  lines.push(`Overall: ${result.overall_status.toUpperCase()}`);
+
+  return `${lines.join("\n")}\n`;
+}
+
+function validateCoveragePolicy(policy: SpecForgePolicyConfig): CiPolicyCheck {
+  const valid =
+    policy.coverage.scope === "changed-lines" &&
+    (policy.coverage.enforcement === "report-only" || policy.coverage.enforcement === "hard-block");
+
+  if (!valid) {
+    return {
+      id: "coverage_policy",
+      status: "fail",
+      message: "Coverage policy must keep changed-lines scope with report-only or hard-block enforcement.",
+      remediation: "Restore coverage.scope=changed-lines and a supported enforcement mode."
+    };
+  }
+
+  return {
+    id: "coverage_policy",
+    status: "pass",
+    message: `Coverage policy is ${policy.coverage.scope}/${policy.coverage.enforcement}.`
+  };
+}
+
+function validateParallelismPolicy(policy: SpecForgePolicyConfig): CiPolicyCheck {
+  const valid =
+    Number.isInteger(policy.parallelism.max_concurrent_tasks) &&
+    policy.parallelism.max_concurrent_tasks > 0 &&
+    typeof policy.parallelism.serialize_on_uncertainty === "boolean";
+
+  if (!valid) {
+    return {
+      id: "parallelism_policy",
+      status: "fail",
+      message: "Parallelism policy must define a positive max_concurrent_tasks and boolean serialize_on_uncertainty.",
+      remediation: "Restore a valid parallelism policy shape before merging."
+    };
+  }
+
+  return {
+    id: "parallelism_policy",
+    status: "pass",
+    message: `Parallelism policy is max=${policy.parallelism.max_concurrent_tasks}, serialize_on_uncertainty=${policy.parallelism.serialize_on_uncertainty}.`
+  };
+}
+
+function validateGatePolicy(policy: SpecForgePolicyConfig): CiPolicyCheck {
+  const gateKeys = Object.keys(policy.gates.enabled_by_default);
+  const enabledDefaultsValid =
+    gateKeys.length === ARTIFACT_GATES.length &&
+    ARTIFACT_GATES.every((gate) => typeof policy.gates.enabled_by_default[gate] === "boolean");
+
+  const applicableModesValid = Object.values(policy.gates.applicable_project_modes).every((modes) =>
+    (modes ?? []).every((mode) => PROJECT_MODES.includes(mode))
+  );
+
+  if (!enabledDefaultsValid || !applicableModesValid) {
+    return {
+      id: "gate_policy",
+      status: "fail",
+      message: "Gate policy must cover known gates and only reference supported project modes.",
+      remediation: "Restore gate defaults and applicable project modes to the known v1 contract."
+    };
+  }
+
+  return {
+    id: "gate_policy",
+    status: "pass",
+    message: "Gate policy covers the known artifact gates and supported project modes."
+  };
+}

--- a/tests/diagnostics/ci-policy.test.ts
+++ b/tests/diagnostics/ci-policy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { createDefaultPolicyConfig } from "../../src/core/contracts/policy.js";
+import {
+  formatCiPolicyReport,
+  runCiPolicyCheck
+} from "../../src/core/diagnostics/ciPolicy.js";
+
+describe("runCiPolicyCheck failure paths", () => {
+  it("fails when the coverage policy deviates from the supported bootstrap modes", () => {
+    const invalidPolicy = createDefaultPolicyConfig();
+    invalidPolicy.coverage.enforcement = "unexpected" as never;
+
+    const result = runCiPolicyCheck(invalidPolicy);
+
+    expect(result.overall_status).toBe("fail");
+    expect(result.checks).toEqual([
+      expect.objectContaining({
+        id: "coverage_policy",
+        status: "fail"
+      }),
+      expect.objectContaining({
+        id: "parallelism_policy",
+        status: "pass"
+      }),
+      expect.objectContaining({
+        id: "gate_policy",
+        status: "pass"
+      })
+    ]);
+  });
+});
+
+describe("runCiPolicyCheck success paths", () => {
+  it("passes the current v1 default policy contract with deterministic report formatting", () => {
+    const result = runCiPolicyCheck(createDefaultPolicyConfig());
+
+    expect(result.overall_status).toBe("pass");
+    expect(result.summary).toEqual({
+      passed: 3,
+      failed: 0
+    });
+
+    const report = formatCiPolicyReport(result);
+    expect(report).toContain("SpecForge CI Policy Check");
+    expect(report).toContain("PASS coverage_policy");
+    expect(report).toContain("PASS parallelism_policy");
+    expect(report).toContain("PASS gate_policy");
+    expect(report).toContain("Summary: 3 passed, 0 failed");
+  });
+});


### PR DESCRIPTION
Closes #35

## Summary
- add a GitHub Actions CI workflow for typecheck, test, build, and policy checks
- add a deterministic CI policy check script and report output
- add a README CI badge so contributors can see workflow status quickly