### PR TITLE
chore: clarify contribution guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ List docs updated, or explain why no docs changes were needed.
 Describe potential risks, migration impact, or rollback considerations.
 
 ## Checklist
-- [ ] Tests pass locally
-- [ ] Lint/typecheck run if applicable
+- [ ] Local checks run as applicable (`pnpm test`, `pnpm typecheck`, `pnpm build`, `pnpm ci:policy`)
 - [ ] Docs updated if required
 - [ ] Change is minimal and scoped
+- [ ] PR targets `main` and links the issue it addresses

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ SpecForge is licensed under Apache License 2.0, which allows commercial and non-
    pnpm test
    pnpm typecheck
    pnpm build
+   pnpm ci:policy
    ```
 
 ## 3. How to Choose an Issue
@@ -29,10 +30,24 @@ SpecForge is licensed under Apache License 2.0, which allows commercial and non-
 4. If unclear, comment on the issue before implementation.
 
 ## 4. Branch Workflow
-1. Create a feature branch from `main` (`feat/...`, `fix/...`, `docs/...`, `chore/...`).
-2. Keep changes minimal and focused to one concern.
-3. Respect the minimal diff policy: avoid unrelated refactors.
-4. Direct commits to `main` are discouraged/prohibited except by explicit maintainer override.
+1. External contributors should work from a GitHub fork, not from branches pushed directly to the upstream repository.
+2. Fork `iKwesi/SpecForge`, clone your fork locally, and add the upstream remote:
+   ```bash
+   git clone <your-fork-url>
+   cd SpecForge
+   git remote add upstream https://github.com/iKwesi/SpecForge.git
+   ```
+3. Sync from `upstream/main` before creating a branch:
+   ```bash
+   git fetch upstream
+   git checkout main
+   git pull --ff-only upstream main
+   ```
+4. Create a single-purpose branch from `main` (`feat/...`, `fix/...`, `docs/...`, `chore/...`).
+5. Push the branch to your fork and open a PR against `main`.
+6. Keep changes minimal and focused to one concern.
+7. Respect the minimal diff policy: avoid unrelated refactors.
+8. Direct commits to `main` are discouraged/prohibited except by explicit maintainer override.
 
 ## 5. Commit Message Standard
 Use Conventional Commits where possible.
@@ -47,16 +62,19 @@ Examples:
 ## 6. Pull Request Expectations
 Each PR should include:
 1. A concise summary of what changed.
-2. A linked issue (or rationale if none exists).
+2. A linked issue (or rationale if none exists). Use `Closes #<issue>` when appropriate.
 3. Why the change is needed.
 4. Risk/impact notes for reviewers.
 5. Evidence that tests/checks were run.
+6. A PR target of `main`, opened from a feature branch or fork branch.
 
 ## 7. Testing Expectations
 1. Run `pnpm test` locally for all changes.
 2. Run `pnpm typecheck` for TypeScript changes.
 3. Run `pnpm build` when touching build-relevant code.
-4. Add or update tests when behavior changes.
+4. Run `pnpm ci:policy` when touching policy, CI, or contribution-gate behavior.
+5. Add or update tests when behavior changes.
+6. GitHub Actions must pass before a PR can merge to `main`.
 
 ## 8. Documentation Expectations
 1. Update docs when behavior, commands, or contributor workflows change.
@@ -68,6 +86,7 @@ Each PR should include:
 2. Call out assumptions and tradeoffs early.
 3. Keep discussion technical, respectful, and evidence-based.
 4. Prefer explicit decisions over implied intent.
+5. If you want to work on an issue, leave a comment first so maintainers can confirm there is no overlap.
 
 ## 10. Terminology Conventions
 Use these terms consistently in code and docs:
@@ -81,3 +100,10 @@ Use these terms consistently in code and docs:
   - skills are orchestrated through the Skill Registry layer
 
 Do not label internal runtime operations as skills.
+
+## 11. Merge Policy
+1. `main` uses protected pull requests, required CI checks, and linear history.
+2. Merge commits are not allowed on `main`.
+3. Maintainers should use `Squash and merge` by default.
+4. `Rebase and merge` is acceptable when preserving multiple intentional commits is important.
+5. Outside contributors do not merge to `main`; maintainers handle the final merge after review and CI.


### PR DESCRIPTION
Closes #39

## Summary
- clarify the fork-first workflow for outside contributors
- align contributor docs and PR checklist with current CI and branch protection rules
- document the maintainer merge policy for linear-history main