### PR TITLE
feat: add changed-lines coverage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -119,13 +121,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate coverage data
+        run: pnpm test:coverage
+
+      - name: Run changed-lines coverage check
+        run: pnpm ci:coverage
+
       - name: Run CI policy check
         run: pnpm ci:policy
 
-      - name: Upload CI policy report
+      - name: Upload CI reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: ci-policy-report
-          path: .specforge/ci/policy-report.txt
+          name: ci-reports
+          path: |
+            .specforge/ci/policy-report.txt
+            .specforge/ci/changed-lines-coverage-report.txt
           if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "ci:coverage": "tsx scripts/run-changed-lines-coverage-check.ts",
     "ci:policy": "tsx scripts/run-ci-policy-check.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "start": "tsx src/cli.ts"
   },
@@ -25,6 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.7.2",
+    "@vitest/coverage-v8": "^3.2.4",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@types/node':
         specifier: ^24.7.2
         version: 24.12.0
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@24.12.0)(tsx@4.21.0))
       tsx:
         specifier: ^4.20.6
         version: 4.21.0
@@ -26,6 +29,31 @@ importers:
         version: 3.2.4(@types/node@24.12.0)(tsx@4.21.0)
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -183,8 +211,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -336,6 +386,15 @@ packages:
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -365,9 +424,42 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -381,9 +473,20 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -397,6 +500,15 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -422,6 +534,10 @@ packages:
       picomatch:
         optional: true
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -430,14 +546,77 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -446,6 +625,17 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -473,8 +663,25 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -486,8 +693,32 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -597,12 +828,45 @@ packages:
       jsdom:
         optional: true
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -682,7 +946,33 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -772,6 +1062,25 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.12.0)(tsx@4.21.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@24.12.0)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -814,7 +1123,35 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   cac@6.7.14: {}
 
@@ -828,13 +1165,31 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   commander@14.0.3: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -877,6 +1232,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -884,17 +1244,94 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-tokens@10.0.0: {}
+
   js-tokens@9.0.1: {}
 
   loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.4
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minipass@7.1.3: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -943,7 +1380,17 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  semver@7.7.4: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -951,9 +1398,39 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.5.0
+      minimatch: 10.2.4
 
   tinybench@2.9.0: {}
 
@@ -1056,7 +1533,23 @@ snapshots:
       - tsx
       - yaml
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0

--- a/scripts/run-changed-lines-coverage-check.ts
+++ b/scripts/run-changed-lines-coverage-check.ts
@@ -1,0 +1,217 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { readFile, mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import { createDefaultPolicyConfig } from "../src/core/contracts/policy.js";
+import {
+  formatChangedLinesCoverageReport,
+  runChangedLinesCoverageCheck
+} from "../src/core/diagnostics/changedLinesCoverage.js";
+
+const execFile = promisify(execFileCallback);
+const EMPTY_GIT_SHA = "0000000000000000000000000000000000000000";
+
+interface ScriptOptions {
+  repo_root?: string;
+  lcov_file?: string;
+  report_file?: string;
+  base_ref?: string;
+  head_ref?: string;
+}
+
+interface GitRange {
+  base_ref: string;
+  head_ref: string;
+  diff_range: string;
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const repoRoot = resolve(options.repo_root ?? process.cwd());
+  const lcovFile = resolve(repoRoot, options.lcov_file ?? join("coverage", "lcov.info"));
+  const reportFile = resolve(
+    repoRoot,
+    options.report_file ?? join(".specforge", "ci", "changed-lines-coverage-report.txt")
+  );
+  const range = await resolveGitRange(options);
+  const [diff, lcov] = await Promise.all([
+    readChangedSourceDiff(repoRoot, range.diff_range),
+    readOptionalFile(lcovFile)
+  ]);
+
+  const result = runChangedLinesCoverageCheck({
+    policy: createDefaultPolicyConfig().coverage,
+    diff,
+    lcov,
+    repo_root: repoRoot,
+    base_ref: range.base_ref,
+    head_ref: range.head_ref
+  });
+  const report = formatChangedLinesCoverageReport(result);
+
+  process.stdout.write(report);
+  await writeReport(reportFile, report);
+
+  if (result.overall_status === "fail") {
+    process.exitCode = 1;
+  }
+}
+
+function parseArgs(argv: string[]): ScriptOptions {
+  const options: ScriptOptions = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const nextValue = argv[index + 1];
+
+    if (!nextValue) {
+      continue;
+    }
+
+    if (token === "--repo-root") {
+      options.repo_root = nextValue;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--lcov-file") {
+      options.lcov_file = nextValue;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--report-file") {
+      options.report_file = nextValue;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--base-ref") {
+      options.base_ref = nextValue;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--head-ref") {
+      options.head_ref = nextValue;
+      index += 1;
+    }
+  }
+
+  return options;
+}
+
+async function resolveGitRange(options: ScriptOptions): Promise<GitRange> {
+  if (options.base_ref && options.head_ref) {
+    return {
+      base_ref: options.base_ref,
+      head_ref: options.head_ref,
+      diff_range: `${options.base_ref}...${options.head_ref}`
+    };
+  }
+
+  const eventPayload = await readGithubEventPayload();
+
+  if (isPullRequestPayload(eventPayload)) {
+    const baseRef = eventPayload.pull_request.base.sha;
+    const headRef = eventPayload.pull_request.head.sha;
+
+    return {
+      base_ref: baseRef,
+      head_ref: headRef,
+      diff_range: `${baseRef}...${headRef}`
+    };
+  }
+
+  if (isPushPayload(eventPayload) && eventPayload.before !== EMPTY_GIT_SHA) {
+    return {
+      base_ref: eventPayload.before,
+      head_ref: eventPayload.after,
+      diff_range: `${eventPayload.before}..${eventPayload.after}`
+    };
+  }
+
+  return {
+    base_ref: "HEAD^",
+    head_ref: "HEAD",
+    diff_range: "HEAD^..HEAD"
+  };
+}
+
+async function readChangedSourceDiff(repoRoot: string, diffRange: string): Promise<string> {
+  const { stdout } = await execFile(
+    "git",
+    ["diff", "--unified=0", "--no-color", diffRange, "--", "src"],
+    {
+      cwd: repoRoot,
+      maxBuffer: 10 * 1024 * 1024
+    }
+  );
+
+  return stdout;
+}
+
+async function readOptionalFile(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "";
+    }
+
+    throw error;
+  }
+}
+
+async function writeReport(path: string, report: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, report, "utf8");
+}
+
+async function readGithubEventPayload(): Promise<unknown | undefined> {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+
+  if (!eventPath) {
+    return undefined;
+  }
+
+  try {
+    const contents = await readFile(eventPath, "utf8");
+    return JSON.parse(contents);
+  } catch {
+    return undefined;
+  }
+}
+
+function isPullRequestPayload(
+  value: unknown
+): value is { pull_request: { base: { sha: string }; head: { sha: string } } } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "pull_request" in value &&
+    typeof value.pull_request === "object" &&
+    value.pull_request !== null &&
+    typeof value.pull_request.base === "object" &&
+    value.pull_request.base !== null &&
+    typeof value.pull_request.head === "object" &&
+    value.pull_request.head !== null &&
+    typeof value.pull_request.base.sha === "string" &&
+    typeof value.pull_request.head.sha === "string"
+  );
+}
+
+function isPushPayload(value: unknown): value is { before: string; after: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { before?: unknown }).before === "string" &&
+    typeof (value as { after?: unknown }).after === "string"
+  );
+}
+
+void main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/core/diagnostics/changedLinesCoverage.ts
+++ b/src/core/diagnostics/changedLinesCoverage.ts
@@ -1,0 +1,325 @@
+import { isAbsolute, normalize, relative } from "node:path";
+
+import type { CoveragePolicy } from "../contracts/policy.js";
+
+export type ChangedLinesCoverageStatus = "pass" | "fail";
+
+export interface ChangedLinesCoverageSummary {
+  changed_source_lines: number;
+  executable_changed_lines: number;
+  covered_lines: number;
+  uncovered_lines: number;
+  missing_coverage_lines: number;
+  non_measurable_lines: number;
+  coverage_percent: number;
+}
+
+export interface ChangedLinesCoverageFileResult {
+  path: string;
+  changed_lines: number[];
+  covered_lines: number[];
+  uncovered_lines: number[];
+  missing_coverage_lines: number[];
+  non_measurable_lines: number[];
+  coverage_percent: number;
+}
+
+export interface ChangedLinesCoverageResult {
+  policy: CoveragePolicy;
+  evaluation_status: ChangedLinesCoverageStatus;
+  overall_status: ChangedLinesCoverageStatus;
+  base_ref?: string;
+  head_ref?: string;
+  summary: ChangedLinesCoverageSummary;
+  files: ChangedLinesCoverageFileResult[];
+}
+
+export interface RunChangedLinesCoverageCheckInput {
+  policy: CoveragePolicy;
+  diff: string;
+  lcov: string;
+  repo_root?: string;
+  base_ref?: string;
+  head_ref?: string;
+}
+
+/**
+ * Evaluate coverage strictly against changed executable source lines.
+ *
+ * For v1 we scope this to `src/` files only so the signal stays grounded in the
+ * core engine code we actually ship, while docs/tests/workflow edits remain out
+ * of coverage enforcement.
+ */
+export function runChangedLinesCoverageCheck(
+  input: RunChangedLinesCoverageCheckInput
+): ChangedLinesCoverageResult {
+  const changedLinesByFile = parseChangedLinesDiff(input.diff);
+  const coverageByFile = parseLcov(input.lcov, input.repo_root);
+
+  const files = [...changedLinesByFile.entries()]
+    .filter(([path]) => isTrackedSourceFile(path))
+    .map(([path, changedLines]) => {
+      const coverageRecord = coverageByFile.get(path);
+
+      if (!coverageRecord) {
+        return buildFileResult(path, changedLines, [], [], changedLines, []);
+      }
+
+      const coveredLines: number[] = [];
+      const uncoveredLines: number[] = [];
+      const missingCoverageLines: number[] = [];
+      const nonMeasurableLines: number[] = [];
+
+      for (const lineNumber of changedLines) {
+        const hitCount = coverageRecord.get(lineNumber);
+
+        if (hitCount === undefined) {
+          nonMeasurableLines.push(lineNumber);
+          continue;
+        }
+
+        if (hitCount > 0) {
+          coveredLines.push(lineNumber);
+        } else {
+          uncoveredLines.push(lineNumber);
+        }
+      }
+
+      return buildFileResult(
+        path,
+        changedLines,
+        coveredLines,
+        uncoveredLines,
+        missingCoverageLines,
+        nonMeasurableLines
+      );
+    })
+    .sort((left, right) => left.path.localeCompare(right.path));
+
+  const summary = files.reduce<ChangedLinesCoverageSummary>(
+    (aggregate, file) => ({
+      changed_source_lines: aggregate.changed_source_lines + file.changed_lines.length,
+      executable_changed_lines:
+        aggregate.executable_changed_lines + file.covered_lines.length + file.uncovered_lines.length,
+      covered_lines: aggregate.covered_lines + file.covered_lines.length,
+      uncovered_lines: aggregate.uncovered_lines + file.uncovered_lines.length,
+      missing_coverage_lines: aggregate.missing_coverage_lines + file.missing_coverage_lines.length,
+      non_measurable_lines: aggregate.non_measurable_lines + file.non_measurable_lines.length,
+      coverage_percent: 0
+    }),
+    {
+      changed_source_lines: 0,
+      executable_changed_lines: 0,
+      covered_lines: 0,
+      uncovered_lines: 0,
+      missing_coverage_lines: 0,
+      non_measurable_lines: 0,
+      coverage_percent: 100
+    }
+  );
+
+  summary.coverage_percent =
+    summary.executable_changed_lines === 0
+      ? 100
+      : roundCoveragePercent((summary.covered_lines / summary.executable_changed_lines) * 100);
+
+  const evaluationStatus: ChangedLinesCoverageStatus =
+    summary.uncovered_lines > 0 || summary.missing_coverage_lines > 0 ? "fail" : "pass";
+  const overallStatus: ChangedLinesCoverageStatus =
+    evaluationStatus === "fail" && input.policy.enforcement === "hard-block" ? "fail" : "pass";
+
+  return {
+    policy: input.policy,
+    evaluation_status: evaluationStatus,
+    overall_status: overallStatus,
+    ...(input.base_ref ? { base_ref: input.base_ref } : {}),
+    ...(input.head_ref ? { head_ref: input.head_ref } : {}),
+    summary,
+    files
+  };
+}
+
+export function formatChangedLinesCoverageReport(result: ChangedLinesCoverageResult): string {
+  const lines = [
+    "SpecForge Changed-Lines Coverage",
+    "",
+    `Policy: ${result.policy.scope}/${result.policy.enforcement}`,
+    ...(result.base_ref || result.head_ref
+      ? [`Range: ${result.base_ref ?? "unknown"} -> ${result.head_ref ?? "unknown"}`]
+      : []),
+    `Evaluation: ${result.evaluation_status.toUpperCase()}`,
+    `Enforcement: ${formatEnforcementStatus(result)}`,
+    "",
+    "Summary",
+    `- changed_source_lines: ${result.summary.changed_source_lines}`,
+    `- executable_changed_lines: ${result.summary.executable_changed_lines}`,
+    `- covered_lines: ${result.summary.covered_lines}`,
+    `- uncovered_lines: ${result.summary.uncovered_lines}`,
+    `- missing_coverage_lines: ${result.summary.missing_coverage_lines}`,
+    `- non_measurable_lines: ${result.summary.non_measurable_lines}`,
+    `- coverage_percent: ${result.summary.coverage_percent}`,
+    "",
+    "Files"
+  ];
+
+  if (result.files.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const file of result.files) {
+      lines.push(
+        `- ${file.path}: covered=${file.covered_lines.length}, uncovered=${file.uncovered_lines.length}, missing=${file.missing_coverage_lines.length}, non_measurable=${file.non_measurable_lines.length}, coverage=${file.coverage_percent}`
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function parseChangedLinesDiff(diff: string): Map<string, number[]> {
+  const changedLinesByFile = new Map<string, Set<number>>();
+  const lines = diff.split(/\r?\n/);
+  let currentFile: string | undefined;
+  let currentLine = 0;
+
+  for (const line of lines) {
+    if (line.startsWith("+++ ")) {
+      currentFile = normalizeDiffPath(line.slice(4));
+      continue;
+    }
+
+    const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+    if (hunkMatch) {
+      const nextLineNumber = hunkMatch[1];
+
+      if (!nextLineNumber) {
+        continue;
+      }
+
+      currentLine = Number.parseInt(nextLineNumber, 10);
+      continue;
+    }
+
+    if (!currentFile) {
+      continue;
+    }
+
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      const currentSet = changedLinesByFile.get(currentFile) ?? new Set<number>();
+      currentSet.add(currentLine);
+      changedLinesByFile.set(currentFile, currentSet);
+      currentLine += 1;
+      continue;
+    }
+
+    if (line.startsWith(" ") || (line.length > 0 && !line.startsWith("-") && !line.startsWith("\\"))) {
+      currentLine += 1;
+    }
+  }
+
+  return new Map(
+    [...changedLinesByFile.entries()].map(([path, changedLines]) => [
+      path,
+      [...changedLines].sort((left, right) => left - right)
+    ])
+  );
+}
+
+function parseLcov(lcov: string, repoRoot?: string): Map<string, Map<number, number>> {
+  const coverageByFile = new Map<string, Map<number, number>>();
+  const lines = lcov.split(/\r?\n/);
+  let currentFile: string | undefined;
+
+  for (const line of lines) {
+    if (line.startsWith("SF:")) {
+      currentFile = normalizeCoveragePath(line.slice(3), repoRoot);
+      continue;
+    }
+
+    if (line.startsWith("DA:") && currentFile) {
+      const [lineNumberValue, hitCountValue] = line.slice(3).split(",", 2);
+
+      if (!lineNumberValue || !hitCountValue) {
+        continue;
+      }
+
+      const lineNumber = Number.parseInt(lineNumberValue, 10);
+      const hitCount = Number.parseInt(hitCountValue, 10);
+
+      if (Number.isNaN(lineNumber) || Number.isNaN(hitCount)) {
+        continue;
+      }
+
+      const record = coverageByFile.get(currentFile) ?? new Map<number, number>();
+      record.set(lineNumber, hitCount);
+      coverageByFile.set(currentFile, record);
+      continue;
+    }
+
+    if (line === "end_of_record") {
+      currentFile = undefined;
+    }
+  }
+
+  return coverageByFile;
+}
+
+function buildFileResult(
+  path: string,
+  changedLines: number[],
+  coveredLines: number[],
+  uncoveredLines: number[],
+  missingCoverageLines: number[],
+  nonMeasurableLines: number[]
+): ChangedLinesCoverageFileResult {
+  const executableChangedLines = coveredLines.length + uncoveredLines.length;
+
+  return {
+    path,
+    changed_lines: [...changedLines],
+    covered_lines: [...coveredLines],
+    uncovered_lines: [...uncoveredLines],
+    missing_coverage_lines: [...missingCoverageLines],
+    non_measurable_lines: [...nonMeasurableLines],
+    coverage_percent:
+      executableChangedLines === 0
+        ? 100
+        : roundCoveragePercent((coveredLines.length / executableChangedLines) * 100)
+  };
+}
+
+function formatEnforcementStatus(result: ChangedLinesCoverageResult): string {
+  if (result.evaluation_status === "pass") {
+    return "PASS";
+  }
+
+  return result.policy.enforcement === "report-only" ? "PASS (report-only)" : "FAIL (hard-block)";
+}
+
+function normalizeDiffPath(value: string): string | undefined {
+  if (value === "/dev/null") {
+    return undefined;
+  }
+
+  return normalizeRepoPath(value.replace(/^b\//, ""));
+}
+
+function normalizeCoveragePath(value: string, repoRoot?: string): string {
+  if (repoRoot && isAbsolute(value)) {
+    const relativePath = relative(repoRoot, value);
+    return normalizeRepoPath(relativePath);
+  }
+
+  return normalizeRepoPath(value);
+}
+
+function normalizeRepoPath(value: string): string {
+  return normalize(value).replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function isTrackedSourceFile(path: string): boolean {
+  return path.startsWith("src/") && path.endsWith(".ts");
+}
+
+function roundCoveragePercent(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/tests/diagnostics/changed-lines-coverage.test.ts
+++ b/tests/diagnostics/changed-lines-coverage.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import { createDefaultPolicyConfig } from "../../src/core/contracts/policy.js";
+import {
+  formatChangedLinesCoverageReport,
+  parseChangedLinesDiff,
+  runChangedLinesCoverageCheck
+} from "../../src/core/diagnostics/changedLinesCoverage.js";
+
+describe("parseChangedLinesDiff", () => {
+  it("captures changed line numbers from zero-context git diff output", () => {
+    const diff = [
+      "diff --git a/src/core/example.ts b/src/core/example.ts",
+      "index 1111111..2222222 100644",
+      "--- a/src/core/example.ts",
+      "+++ b/src/core/example.ts",
+      "@@ -10,0 +11,2 @@",
+      "+const covered = true;",
+      "+const uncovered = false;",
+      "@@ -20 +22 @@",
+      "-return oldValue;",
+      "+return newValue;"
+    ].join("\n");
+
+    const changedLines = parseChangedLinesDiff(diff);
+
+    expect(changedLines).toEqual(
+      new Map<string, number[]>([["src/core/example.ts", [11, 12, 22]]])
+    );
+  });
+});
+
+describe("runChangedLinesCoverageCheck", () => {
+  it("reports uncovered changed lines without failing overall in report-only mode", () => {
+    const policy = createDefaultPolicyConfig().coverage;
+    const diff = [
+      "diff --git a/src/core/example.ts b/src/core/example.ts",
+      "index 1111111..2222222 100644",
+      "--- a/src/core/example.ts",
+      "+++ b/src/core/example.ts",
+      "@@ -10,0 +11,2 @@",
+      "+const covered = true;",
+      "+const uncovered = false;"
+    ].join("\n");
+    const lcov = [
+      "TN:",
+      "SF:src/core/example.ts",
+      "DA:11,1",
+      "DA:12,0",
+      "end_of_record"
+    ].join("\n");
+
+    const result = runChangedLinesCoverageCheck({
+      policy,
+      diff,
+      lcov
+    });
+
+    expect(result.evaluation_status).toBe("fail");
+    expect(result.overall_status).toBe("pass");
+    expect(result.summary).toEqual({
+      changed_source_lines: 2,
+      executable_changed_lines: 2,
+      covered_lines: 1,
+      uncovered_lines: 1,
+      missing_coverage_lines: 0,
+      non_measurable_lines: 0,
+      coverage_percent: 50
+    });
+    expect(result.files).toEqual([
+      expect.objectContaining({
+        path: "src/core/example.ts",
+        covered_lines: [11],
+        uncovered_lines: [12],
+        missing_coverage_lines: [],
+        non_measurable_lines: []
+      })
+    ]);
+
+    const report = formatChangedLinesCoverageReport(result);
+    expect(report).toContain("SpecForge Changed-Lines Coverage");
+    expect(report).toContain("Evaluation: FAIL");
+    expect(report).toContain("Enforcement: PASS (report-only)");
+  });
+
+  it("fails overall in hard-block mode when a changed source file has no coverage record", () => {
+    const policy = {
+      ...createDefaultPolicyConfig().coverage,
+      enforcement: "hard-block" as const
+    };
+    const diff = [
+      "diff --git a/src/core/missing.ts b/src/core/missing.ts",
+      "index 1111111..2222222 100644",
+      "--- a/src/core/missing.ts",
+      "+++ b/src/core/missing.ts",
+      "@@ -4,0 +5,2 @@",
+      "+export const value = 1;",
+      "+export const nextValue = value + 1;"
+    ].join("\n");
+    const lcov = [
+      "TN:",
+      "SF:src/core/example.ts",
+      "DA:11,1",
+      "end_of_record"
+    ].join("\n");
+
+    const result = runChangedLinesCoverageCheck({
+      policy,
+      diff,
+      lcov
+    });
+
+    expect(result.evaluation_status).toBe("fail");
+    expect(result.overall_status).toBe("fail");
+    expect(result.summary.missing_coverage_lines).toBe(2);
+    expect(result.files).toEqual([
+      expect.objectContaining({
+        path: "src/core/missing.ts",
+        missing_coverage_lines: [5, 6]
+      })
+    ]);
+  });
+
+  it("ignores changed files outside src when evaluating changed-lines coverage", () => {
+    const policy = createDefaultPolicyConfig().coverage;
+    const diff = [
+      "diff --git a/README.md b/README.md",
+      "index 1111111..2222222 100644",
+      "--- a/README.md",
+      "+++ b/README.md",
+      "@@ -1 +1 @@",
+      "-Old line",
+      "+New line"
+    ].join("\n");
+
+    const result = runChangedLinesCoverageCheck({
+      policy,
+      diff,
+      lcov: ""
+    });
+
+    expect(result.evaluation_status).toBe("pass");
+    expect(result.overall_status).toBe("pass");
+    expect(result.summary).toEqual({
+      changed_source_lines: 0,
+      executable_changed_lines: 0,
+      covered_lines: 0,
+      uncovered_lines: 0,
+      missing_coverage_lines: 0,
+      non_measurable_lines: 0,
+      coverage_percent: 100
+    });
+    expect(result.files).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,8 +6,10 @@ export default defineConfig({
     environment: "node",
     coverage: {
       provider: "v8",
-      reporter: ["text", "json-summary", "lcov"]
+      reporter: ["text", "json-summary", "lcov"],
+      all: true,
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.d.ts"]
     }
   }
 });
-


### PR DESCRIPTION
## Summary
- add a deterministic changed-lines coverage evaluator for source files
- wire coverage generation and reporting into the CI policy lane
- keep coverage report-only by default while preserving hard-block support in policy

Closes #36
