### PR TITLE
feat: add global dry-run previews

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -183,12 +183,14 @@ The command reads artifact inputs and optional policy/schedule context, then pri
       "Parent/output directory under which the .specforge artifact directory will be created"
     )
     .option("--deep", "Increase the bounded scan budget for deeper repository inspection")
+    .option("--dry-run", "Report planned artifact writes without publishing them")
     .addHelpText(
       "after",
       `
 Examples:
   $ specforge inspect
   $ specforge inspect --repository-root ../my-repo --artifact-dir ../my-repo --deep
+  $ specforge inspect --repository-root . --dry-run
 
 What it produces:
   - a repository profile artifact
@@ -198,12 +200,18 @@ Use this before planning or task decomposition when you need a bounded view of a
 `
     )
     .action(
-      async (options: { repositoryRoot?: string; artifactDir?: string; deep?: boolean }) => {
+      async (options: {
+        repositoryRoot?: string;
+        artifactDir?: string;
+        deep?: boolean;
+        dryRun?: boolean;
+      }) => {
         try {
           const result = await inspectRunner({
             repository_root: options.repositoryRoot ?? process.cwd(),
             ...(options.artifactDir ? { artifact_dir: options.artifactDir } : {}),
             ...(options.deep ? { deep: true } : {}),
+            ...(options.dryRun ? { dry_run: true } : {}),
             ...(inspectInput ?? {})
           });
 

--- a/src/core/contracts/dryRun.ts
+++ b/src/core/contracts/dryRun.ts
@@ -1,0 +1,39 @@
+export type DryRunChangeStatus = "planned" | "blocked";
+
+export type DryRunChangeKind =
+  | "artifact_write"
+  | "task_execution"
+  | "branch_create"
+  | "workspace_prepare"
+  | "workspace_remove"
+  | "gate_blocked";
+
+export interface DryRunChange {
+  status: DryRunChangeStatus;
+  kind: DryRunChangeKind;
+  target: string;
+  detail: string;
+}
+
+export interface DryRunReport {
+  enabled: true;
+  changes: DryRunChange[];
+}
+
+/**
+ * Dry-run reports stay explicit and ordered so callers can explain exactly which
+ * mutations were suppressed, without inferring intent from operation-specific fields.
+ */
+export function createDryRunReport(changes: DryRunChange[]): DryRunReport {
+  return {
+    enabled: true,
+    changes: [...changes]
+  };
+}
+
+export function mergeDryRunReports(
+  ...reports: Array<DryRunReport | undefined>
+): DryRunReport | undefined {
+  const changes = reports.flatMap((report) => report?.changes ?? []);
+  return changes.length > 0 ? createDryRunReport(changes) : undefined;
+}

--- a/src/core/diagnostics/inspect.ts
+++ b/src/core/diagnostics/inspect.ts
@@ -1,16 +1,19 @@
 import { join } from "node:path";
 
+import { mergeDryRunReports, type DryRunReport } from "../contracts/dryRun.js";
 import type { ArchitectureSummaryArtifact } from "../operations/mapArchitectureFromRepo.js";
 import {
   MapArchitectureFromRepoError,
   runMapArchitectureFromRepo,
-  type MapArchitectureFromRepoInput
+  type MapArchitectureFromRepoInput,
+  type MapArchitectureFromRepoResult
 } from "../operations/mapArchitectureFromRepo.js";
 import type { RepoProfileArtifact } from "../operations/profileRepository.js";
 import {
   ProfileRepositoryError,
   runProfileRepository,
-  type ProfileRepositoryInput
+  type ProfileRepositoryInput,
+  type ProfileRepositoryResult
 } from "../operations/profileRepository.js";
 
 const STANDARD_MAX_FILES = 200;
@@ -38,17 +41,17 @@ export interface InspectResult {
   architecture_summary_path: string;
   repo_profile: RepoProfileArtifact;
   architecture_summary: ArchitectureSummaryArtifact;
+  dry_run?: DryRunReport;
 }
 
 export interface RunInspectInput {
   repository_root?: string;
   artifact_dir?: string;
   deep?: boolean;
+  dry_run?: boolean;
   created_timestamp?: Date;
-  profile_runner?: (input: ProfileRepositoryInput) => Promise<{ repo_profile: RepoProfileArtifact }>;
-  architecture_runner?: (
-    input: MapArchitectureFromRepoInput
-  ) => Promise<{ architecture_summary: ArchitectureSummaryArtifact }>;
+  profile_runner?: (input: ProfileRepositoryInput) => Promise<ProfileRepositoryResult>;
+  architecture_runner?: (input: MapArchitectureFromRepoInput) => Promise<MapArchitectureFromRepoResult>;
 }
 
 /**
@@ -66,6 +69,7 @@ export async function runInspect(input: RunInspectInput = {}): Promise<InspectRe
   const maxFiles = scanMode === "deep" ? DEEP_MAX_FILES : STANDARD_MAX_FILES;
   const profileRunner = input.profile_runner ?? runProfileRepository;
   const architectureRunner = input.architecture_runner ?? runMapArchitectureFromRepo;
+  let dryRun: DryRunReport | undefined;
 
   let repoProfile: RepoProfileArtifact;
   try {
@@ -74,9 +78,11 @@ export async function runInspect(input: RunInspectInput = {}): Promise<InspectRe
       repository_root: repositoryRoot,
       ...(profileArtifactDir ? { artifact_dir: profileArtifactDir } : {}),
       max_files: maxFiles,
+      ...(input.dry_run ? { dry_run: true } : {}),
       ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
     });
     repoProfile = result.repo_profile;
+    dryRun = mergeDryRunReports(dryRun, "dry_run" in result ? result.dry_run : undefined);
   } catch (error) {
     if (error instanceof ProfileRepositoryError) {
       throw new InspectError(
@@ -95,9 +101,11 @@ export async function runInspect(input: RunInspectInput = {}): Promise<InspectRe
       project_mode: "existing-repo",
       repo_profile: repoProfile,
       artifact_dir: artifactRoot,
+      ...(input.dry_run ? { dry_run: true } : {}),
       ...(input.created_timestamp ? { created_timestamp: input.created_timestamp } : {})
     });
     architectureSummary = result.architecture_summary;
+    dryRun = mergeDryRunReports(dryRun, "dry_run" in result ? result.dry_run : undefined);
   } catch (error) {
     if (error instanceof MapArchitectureFromRepoError) {
       throw new InspectError(
@@ -116,7 +124,8 @@ export async function runInspect(input: RunInspectInput = {}): Promise<InspectRe
     repo_profile_path: join(artifactRoot, ".specforge", "repo_profile.json"),
     architecture_summary_path: join(artifactRoot, ".specforge", "architecture_summary.json"),
     repo_profile: repoProfile,
-    architecture_summary: architectureSummary
+    architecture_summary: architectureSummary,
+    ...(dryRun ? { dry_run: dryRun } : {})
   };
 }
 
@@ -129,7 +138,18 @@ export function formatInspectReport(result: InspectResult): string {
     `Repo Profile: ${result.repo_profile.metadata.artifact_id}@${result.repo_profile.metadata.artifact_version}`,
     `Architecture Summary: ${result.architecture_summary.metadata.artifact_id}@${result.architecture_summary.metadata.artifact_version}`,
     `Repo Profile Path: ${result.repo_profile_path}`,
-    `Architecture Summary Path: ${result.architecture_summary_path}`,
+    `Architecture Summary Path: ${result.architecture_summary_path}`
+  ];
+
+  if (result.dry_run) {
+    lines.push("", "Dry Run: enabled");
+    for (const change of result.dry_run.changes) {
+      lines.push(`- ${change.status} ${change.kind}: ${change.target}`);
+      lines.push(`  ${change.detail}`);
+    }
+  }
+
+  lines.push(
     "",
     "Repo Profile Evidence",
     `- scanned_file_count: ${result.repo_profile.scan.scanned_file_count}`,
@@ -138,7 +158,7 @@ export function formatInspectReport(result: InspectResult): string {
     `- detected_tooling: ${result.repo_profile.evidence.detected_tooling.join(", ") || "none"}`,
     "",
     "Architecture Subsystems"
-  ];
+  );
 
   for (const subsystem of result.architecture_summary.subsystems) {
     lines.push(

--- a/src/core/execution/workspaceManager.ts
+++ b/src/core/execution/workspaceManager.ts
@@ -1,6 +1,7 @@
 import { lstat, mkdir, realpath } from "node:fs/promises";
 import { join } from "node:path";
 
+import { createDryRunReport, type DryRunReport } from "../contracts/dryRun.js";
 import {
   GitProviderError,
   resolveGitProvider,
@@ -43,6 +44,7 @@ export interface TaskWorkspaceManagerInput extends TaskWorkspaceTargetInput {
   preferred_provider?: GitProviderName;
   git_binary?: string;
   git_provider?: GitProvider;
+  dry_run?: boolean;
 }
 
 export interface PrepareTaskWorkspaceResult {
@@ -52,6 +54,7 @@ export interface PrepareTaskWorkspaceResult {
   created: boolean;
   selected_provider: GitProviderName;
   fallback_used: boolean;
+  dry_run?: DryRunReport;
 }
 
 export interface CleanupTaskWorkspaceResult {
@@ -61,6 +64,7 @@ export interface CleanupTaskWorkspaceResult {
   removed: boolean;
   selected_provider: GitProviderName;
   fallback_used: boolean;
+  dry_run?: DryRunReport;
 }
 
 /**
@@ -76,6 +80,31 @@ export async function prepareTaskWorkspace(
   const target = resolveTaskWorkspaceTarget(input);
   const providerResolution = await resolveWorkspaceProvider(input);
   const provider = providerResolution.provider;
+
+  if (input.dry_run) {
+    return {
+      task_id: target.task_id,
+      branch_name: target.branch_name,
+      workspace_path: target.workspace_path,
+      created: false,
+      selected_provider: providerResolution.selected_provider,
+      fallback_used: providerResolution.fallback_used,
+      dry_run: createDryRunReport([
+        {
+          status: "planned",
+          kind: "branch_create",
+          target: target.branch_name,
+          detail: "Would create or reuse the task branch for isolated execution."
+        },
+        {
+          status: "planned",
+          kind: "workspace_prepare",
+          target: target.workspace_path,
+          detail: "Would prepare an isolated task worktree without mutating the current checkout."
+        }
+      ])
+    };
+  }
 
   await mkdir(target.workspace_root, { recursive: true });
 
@@ -158,6 +187,26 @@ export async function cleanupTaskWorkspace(
   const target = resolveTaskWorkspaceTarget(input);
   const providerResolution = await resolveWorkspaceProvider(input);
   const provider = providerResolution.provider;
+
+  if (input.dry_run) {
+    return {
+      task_id: target.task_id,
+      branch_name: target.branch_name,
+      workspace_path: target.workspace_path,
+      removed: false,
+      selected_provider: providerResolution.selected_provider,
+      fallback_used: providerResolution.fallback_used,
+      dry_run: createDryRunReport([
+        {
+          status: "planned",
+          kind: "workspace_remove",
+          target: target.workspace_path,
+          detail: "Would remove the isolated task worktree without mutating the active checkout."
+        }
+      ])
+    };
+  }
+
   const worktrees = await provider.listWorktrees({ repo_root: input.repo_root });
   const normalizedWorkspacePath = await normalizePathIfExists(target.workspace_path);
   const existingWorkspace = findWorktreeByPath(worktrees, normalizedWorkspacePath);

--- a/src/core/operations/devTDDTask.ts
+++ b/src/core/operations/devTDDTask.ts
@@ -6,6 +6,7 @@ import {
   createInitialArtifactMetadata,
   createNextArtifactMetadata
 } from "../artifacts/versioning.js";
+import { createDryRunReport, type DryRunReport } from "../contracts/dryRun.js";
 import type { ProjectMode } from "../contracts/domain.js";
 import type { OperationContract } from "../contracts/operation.js";
 import type { ContextPackArtifact } from "./buildContextPack.js";
@@ -50,6 +51,7 @@ export interface DevTddTaskInput {
   branch_ref?: string;
   pr_ref?: string;
   artifact_dir?: string;
+  dry_run?: boolean;
   created_timestamp?: Date;
 }
 
@@ -77,6 +79,7 @@ export interface TaskExecutionResultArtifact {
 
 export interface DevTddTaskResult {
   task_execution_result: TaskExecutionResultArtifact;
+  dry_run?: DryRunReport;
 }
 
 export const DEV_TDD_TASK_OPERATION_CONTRACT: OperationContract<
@@ -177,7 +180,7 @@ export async function runDevTddTask(input: DevTddTaskInput): Promise<DevTddTaskR
     summary_markdown: summaryMarkdown
   };
 
-  if (artifactDir) {
+  if (artifactDir && !input.dry_run) {
     await writeTaskExecutionResultArtifact({
       artifact_dir: artifactDir,
       task_id: contextPack.task.id,
@@ -186,7 +189,19 @@ export async function runDevTddTask(input: DevTddTaskInput): Promise<DevTddTaskR
   }
 
   return {
-    task_execution_result: taskExecutionResult
+    task_execution_result: taskExecutionResult,
+    ...(input.dry_run
+      ? {
+          dry_run: createDryRunReport([
+            {
+              status: "planned",
+              kind: "task_execution",
+              target: contextPack.task.id,
+              detail: `Would publish ${join(artifactDir ?? ".", TASK_RESULTS_DIR, `${contextPack.task.id}.json`)} after a valid RED/GREEN/REFACTOR transcript.`
+            }
+          ])
+        }
+      : {})
   };
 }
 

--- a/src/core/operations/generateProposalBrief.ts
+++ b/src/core/operations/generateProposalBrief.ts
@@ -6,6 +6,7 @@ import {
   createInitialArtifactMetadata,
   createNextArtifactMetadata
 } from "../artifacts/versioning.js";
+import { createDryRunReport, type DryRunReport } from "../contracts/dryRun.js";
 import type { ArtifactGate, ProjectMode } from "../contracts/domain.js";
 import type { OperationContract } from "../contracts/operation.js";
 import {
@@ -58,6 +59,7 @@ export interface GenerateProposalBriefInput {
   idea_brief_status?: string;
   repository_ownership: ProposalRepositoryOwnership;
   artifact_dir?: string;
+  dry_run?: boolean;
   created_timestamp?: Date;
 }
 
@@ -92,6 +94,7 @@ export interface GenerateProposalBriefResult {
   proposal_summary: ProposalSummaryArtifact;
   proposal_draft: ProposalDraftArtifact;
   workflow: ProposalWorkflowRoute;
+  dry_run?: DryRunReport;
 }
 
 export const GENERATE_PROPOSAL_BRIEF_OPERATION_CONTRACT: OperationContract<
@@ -209,7 +212,7 @@ export async function runGenerateProposalBrief(
     content: draftContent
   };
 
-  if (input.artifact_dir) {
+  if (input.artifact_dir && !input.dry_run) {
     await writeProposalArtifacts({
       artifact_dir: input.artifact_dir,
       proposal_summary,
@@ -220,7 +223,31 @@ export async function runGenerateProposalBrief(
   return {
     proposal_summary,
     proposal_draft,
-    workflow
+    workflow,
+    ...(input.dry_run
+      ? {
+          dry_run: createDryRunReport([
+            {
+              status: "blocked",
+              kind: "gate_blocked",
+              target: workflow.required_gate,
+              detail: "Would stop for proposal_approval before any repository-facing handoff."
+            },
+            {
+              status: "planned",
+              kind: "artifact_write",
+              target: join(input.artifact_dir ?? ".", PROPOSAL_SUMMARY_FILENAME),
+              detail: "Would publish proposal_summary.md for feature-proposal review."
+            },
+            {
+              status: "planned",
+              kind: "artifact_write",
+              target: join(input.artifact_dir ?? ".", proposal_draft.path),
+              detail: `Would publish ${proposal_draft.path} for feature-proposal review.`
+            }
+          ])
+        }
+      : {})
   };
 }
 

--- a/src/core/operations/mapArchitectureFromRepo.ts
+++ b/src/core/operations/mapArchitectureFromRepo.ts
@@ -6,6 +6,7 @@ import {
   createInitialArtifactMetadata,
   createNextArtifactMetadata
 } from "../artifacts/versioning.js";
+import { createDryRunReport, type DryRunReport } from "../contracts/dryRun.js";
 import type { ProjectMode } from "../contracts/domain.js";
 import type { OperationContract } from "../contracts/operation.js";
 import type { RepoProfileArtifact } from "./profileRepository.js";
@@ -36,11 +37,13 @@ export interface MapArchitectureFromRepoInput {
   project_mode: ProjectMode;
   repo_profile?: RepoProfileArtifact;
   artifact_dir?: string;
+  dry_run?: boolean;
   created_timestamp?: Date;
 }
 
 export interface MapArchitectureFromRepoResult {
   architecture_summary: ArchitectureSummaryArtifact;
+  dry_run?: DryRunReport;
 }
 
 export type MapArchitectureFromRepoErrorCode =
@@ -133,7 +136,7 @@ export async function runMapArchitectureFromRepo(
     summary_markdown: summaryMarkdown
   };
 
-  if (input.artifact_dir) {
+  if (input.artifact_dir && !input.dry_run) {
     await writeArchitectureSummaryArtifact({
       artifact_dir: input.artifact_dir,
       architecture_summary: architectureSummary
@@ -141,7 +144,19 @@ export async function runMapArchitectureFromRepo(
   }
 
   return {
-    architecture_summary: architectureSummary
+    architecture_summary: architectureSummary,
+    ...(input.dry_run && input.artifact_dir
+      ? {
+          dry_run: createDryRunReport([
+            {
+              status: "planned",
+              kind: "artifact_write",
+              target: join(input.artifact_dir, ".specforge", ARCHITECTURE_SUMMARY_FILENAME),
+              detail: "Would publish architecture_summary artifact metadata without mutating the repository."
+            }
+          ])
+        }
+      : {})
   };
 }
 

--- a/src/core/operations/profileRepository.ts
+++ b/src/core/operations/profileRepository.ts
@@ -6,6 +6,7 @@ import {
   createInitialArtifactMetadata,
   createNextArtifactMetadata
 } from "../artifacts/versioning.js";
+import { createDryRunReport, type DryRunReport } from "../contracts/dryRun.js";
 import type { ProjectMode } from "../contracts/domain.js";
 import type { OperationContract } from "../contracts/operation.js";
 
@@ -62,6 +63,7 @@ export interface ProfileRepositoryInput {
   artifact_dir?: string;
   max_files?: number;
   ignore_directories?: string[];
+  dry_run?: boolean;
   created_timestamp?: Date;
 }
 
@@ -96,6 +98,7 @@ export interface RepoProfileArtifact {
 
 export interface ProfileRepositoryResult {
   repo_profile: RepoProfileArtifact;
+  dry_run?: DryRunReport;
 }
 
 export const PROFILE_REPOSITORY_OPERATION_CONTRACT: OperationContract<
@@ -153,9 +156,8 @@ export async function runProfileRepository(
     ignored_directories: [...ignoredDirectories]
   };
 
-  const previousVersion = await readExistingRepoProfileVersion(
-    resolveArtifactDirectory(input.repository_root, input.artifact_dir)
-  );
+  const resolvedArtifactDirectory = resolveArtifactDirectory(input.repository_root, input.artifact_dir);
+  const previousVersion = await readExistingRepoProfileVersion(resolvedArtifactDirectory);
 
   const content = JSON.stringify({
     repository_root: input.repository_root,
@@ -191,13 +193,27 @@ export async function runProfileRepository(
     }
   };
 
-  await writeRepoProfileArtifact({
-    artifact_dir: resolveArtifactDirectory(input.repository_root, input.artifact_dir),
-    repo_profile: repoProfile
-  });
+  if (!input.dry_run) {
+    await writeRepoProfileArtifact({
+      artifact_dir: resolvedArtifactDirectory,
+      repo_profile: repoProfile
+    });
+  }
 
   return {
-    repo_profile: repoProfile
+    repo_profile: repoProfile,
+    ...(input.dry_run
+      ? {
+          dry_run: createDryRunReport([
+            {
+              status: "planned",
+              kind: "artifact_write",
+              target: join(resolvedArtifactDirectory, REPO_PROFILE_FILENAME),
+              detail: "Would publish repo_profile artifact metadata without mutating the repository."
+            }
+          ])
+        }
+      : {})
   };
 }
 

--- a/tests/cli/inspect-command.test.ts
+++ b/tests/cli/inspect-command.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { runCli } from "../../src/cli.js";
 import type { InspectResult } from "../../src/core/diagnostics/inspect.js";
+import type { DryRunReport } from "../../src/core/contracts/dryRun.js";
 
 function buildInspectResult(overrides: Partial<InspectResult> = {}): InspectResult {
   return {
@@ -100,5 +101,39 @@ describe("sf inspect command", () => {
 
     expect(exitCode).toBe(1);
     expect(stderr).toContain("inspect failed");
+  });
+
+  it("passes --dry-run through to inspect and prints planned side effects", async () => {
+    let stdout = "";
+    let receivedDryRun = false;
+    const dryRun: DryRunReport = {
+      enabled: true,
+      changes: [
+        {
+          status: "planned",
+          kind: "artifact_write",
+          target: "/workspace/specforge/.specforge/repo_profile.json",
+          detail: "Would publish repo_profile artifact metadata without mutating the repository."
+        }
+      ]
+    };
+
+    const exitCode = await runCli(["node", "sf", "inspect", "--dry-run"], {
+      stdout: {
+        write(chunk: string) {
+          stdout += chunk;
+          return true;
+        }
+      },
+      inspect_runner: async (input) => {
+        receivedDryRun = input?.dry_run === true;
+        return buildInspectResult({ dry_run: dryRun });
+      }
+    });
+
+    expect(exitCode).toBe(0);
+    expect(receivedDryRun).toBe(true);
+    expect(stdout).toContain("Dry Run: enabled");
+    expect(stdout).toContain("Would publish repo_profile artifact metadata");
   });
 });

--- a/tests/diagnostics/inspect.test.ts
+++ b/tests/diagnostics/inspect.test.ts
@@ -116,4 +116,46 @@ describe("runInspect success paths", () => {
     expect(deep.repo_profile.scan.max_files).toBe(1000);
     expect(deep.repo_profile.scan.truncated).toBe(false);
   });
+
+  it("reports planned artifact writes without publishing artifacts when dry_run is enabled", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "specforge-inspect-dry-run-"));
+
+    await writeRepoFiles(repoRoot, [
+      { path: "package.json", content: "{\"name\":\"demo\"}" },
+      { path: "src/api/routes.ts", content: "export const routes = [];" },
+      { path: "src/api/service.ts", content: "export const service = {};" }
+    ]);
+
+    const result = await runInspect({
+      repository_root: repoRoot,
+      dry_run: true,
+      created_timestamp: new Date("2026-03-14T00:10:00.000Z")
+    });
+
+    expect(result.dry_run).toEqual({
+      enabled: true,
+      changes: [
+        {
+          status: "planned",
+          kind: "artifact_write",
+          target: join(repoRoot, ".specforge", "repo_profile.json"),
+          detail: "Would publish repo_profile artifact metadata without mutating the repository."
+        },
+        {
+          status: "planned",
+          kind: "artifact_write",
+          target: join(repoRoot, ".specforge", "architecture_summary.json"),
+          detail: "Would publish architecture_summary artifact metadata without mutating the repository."
+        }
+      ]
+    });
+    expect((await readdir(repoRoot)).sort((left, right) => left.localeCompare(right))).toEqual([
+      "package.json",
+      "src"
+    ]);
+
+    const report = formatInspectReport(result);
+    expect(report).toContain("Dry Run: enabled");
+    expect(report).toContain("Would publish repo_profile artifact metadata");
+  });
 });

--- a/tests/execution/dev-tdd-task.test.ts
+++ b/tests/execution/dev-tdd-task.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -249,5 +249,53 @@ describe("devTDDTask success paths", () => {
 
     expect(second.task_execution_result.metadata.artifact_version).toBe("v2");
     expect(second.task_execution_result.metadata.parent_version).toBe("v1");
+  });
+
+  it("reports the planned task execution artifact without writing files in dry_run mode", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-dev-tdd-task-dry-run-"));
+
+    const result = await runDevTddTask({
+      project_mode: "existing-repo",
+      context_pack: buildContextPack(),
+      phases: [
+        {
+          phase: "red",
+          status: "failed",
+          summary: "Added a failing acceptance-focused test.",
+          evidence: ["tests/task.test.ts"],
+          commands: ["pnpm test -- --run tests/task.test.ts"]
+        },
+        {
+          phase: "green",
+          status: "passed",
+          summary: "Implemented the minimal production change.",
+          evidence: ["src/task.ts", "tests/task.test.ts"],
+          commands: ["pnpm test -- --run tests/task.test.ts"]
+        },
+        {
+          phase: "refactor",
+          status: "passed",
+          summary: "Simplified the implementation and reran tests.",
+          evidence: ["src/task.ts"],
+          commands: ["pnpm test -- --run tests/task.test.ts", "pnpm typecheck"]
+        }
+      ],
+      artifact_dir: artifactDir,
+      dry_run: true,
+      created_timestamp: new Date("2026-03-13T13:20:00.000Z")
+    });
+
+    expect(result.dry_run).toEqual({
+      enabled: true,
+      changes: [
+        {
+          status: "planned",
+          kind: "task_execution",
+          target: "TASK-1",
+          detail: `Would publish ${join(artifactDir, ".specforge", "task-results", "TASK-1.json")} after a valid RED/GREEN/REFACTOR transcript.`
+        }
+      ]
+    });
+    expect(await readdir(artifactDir)).toEqual([]);
   });
 });

--- a/tests/execution/workspace-manager.test.ts
+++ b/tests/execution/workspace-manager.test.ts
@@ -80,6 +80,43 @@ describe("workspace manager", () => {
     expect(worktrees.filter((worktree) => worktree.branch_name === "feat/task-1")).toHaveLength(1);
   });
 
+  it("reports planned branch and worktree creation without mutating git state in dry_run mode", async () => {
+    const repoRoot = await createRepository();
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "specforge-workspaces-"));
+    const provider = createNativeGitProvider();
+
+    const result = await prepareTaskWorkspace({
+      repo_root: repoRoot,
+      workspace_root: workspaceRoot,
+      task_id: "TASK-1",
+      git_provider: provider,
+      dry_run: true
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.dry_run).toEqual({
+      enabled: true,
+      changes: [
+        {
+          status: "planned",
+          kind: "branch_create",
+          target: "feat/task-1",
+          detail: "Would create or reuse the task branch for isolated execution."
+        },
+        {
+          status: "planned",
+          kind: "workspace_prepare",
+          target: join(workspaceRoot, "task-1"),
+          detail: "Would prepare an isolated task worktree without mutating the current checkout."
+        }
+      ]
+    });
+
+    expect(await runGit(["branch", "--list", "feat/task-1"], repoRoot)).toBe("");
+    const worktrees = await provider.listWorktrees({ repo_root: repoRoot });
+    expect(worktrees.some((worktree) => worktree.branch_name === "feat/task-1")).toBe(false);
+  });
+
   it("recreates a cleaned task workspace even when the branch already exists", async () => {
     const repoRoot = await createRepository();
     const workspaceRoot = await mkdtemp(join(tmpdir(), "specforge-workspaces-"));

--- a/tests/planning/generate-proposal-brief.test.ts
+++ b/tests/planning/generate-proposal-brief.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -184,5 +184,44 @@ describe("generateProposalBrief success paths", () => {
     expect(second.proposal_summary.metadata.parent_version).toBe("v1");
     expect(second.proposal_draft.metadata.artifact_version).toBe("v2");
     expect(second.proposal_draft.metadata.parent_version).toBe("v1");
+  });
+
+  it("reports planned artifacts and blocked approval gate without writing files in dry_run mode", async () => {
+    const artifactDir = await mkdtemp(join(tmpdir(), "specforge-proposal-dry-run-"));
+
+    const result = await runGenerateProposalBrief({
+      project_mode: "feature-proposal",
+      idea_brief_status: "approved",
+      repository_ownership: "owned",
+      idea_brief: buildIdeaBrief(),
+      artifact_dir: artifactDir,
+      dry_run: true,
+      created_timestamp: new Date("2026-03-12T12:30:00.000Z")
+    });
+
+    expect(result.dry_run).toEqual({
+      enabled: true,
+      changes: [
+        {
+          status: "blocked",
+          kind: "gate_blocked",
+          target: "proposal_approval",
+          detail: "Would stop for proposal_approval before any repository-facing handoff."
+        },
+        {
+          status: "planned",
+          kind: "artifact_write",
+          target: join(artifactDir, "proposal_summary.md"),
+          detail: "Would publish proposal_summary.md for feature-proposal review."
+        },
+        {
+          status: "planned",
+          kind: "artifact_write",
+          target: join(artifactDir, "proposal_issue.md"),
+          detail: "Would publish proposal_issue.md for feature-proposal review."
+        }
+      ]
+    });
+    expect(await readdir(artifactDir)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- add a shared dry-run contract for planned and blocked side effects
- support dry-run previews for inspect, proposal generation, task execution, and workspace isolation
- expose specforge inspect --dry-run with deterministic preview output

## Testing
- pnpm test
- pnpm typecheck
- pnpm build

Closes #32