### PR TITLE
feat: add github status integration

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,12 @@ import {
   type InspectResult,
   type RunInspectInput
 } from "./core/diagnostics/inspect.js";
+import {
+  formatStatusReport,
+  runStatus,
+  type RunStatusInput,
+  type StatusResult
+} from "./core/diagnostics/status.js";
 
 interface CliWriter {
   write(chunk: string): boolean | void;
@@ -33,6 +39,8 @@ export interface CliDependencies {
   explain_input?: Partial<RunExplainInput>;
   inspect_runner?: (input?: RunInspectInput) => Promise<InspectResult>;
   inspect_input?: Partial<RunInspectInput>;
+  status_runner?: (input: RunStatusInput) => Promise<StatusResult>;
+  status_input?: Partial<RunStatusInput>;
 }
 
 class CliExitSignal extends Error {
@@ -54,6 +62,8 @@ export function createProgram(dependencies: CliDependencies = {}): Command {
   const explainInput = dependencies.explain_input;
   const inspectRunner = dependencies.inspect_runner ?? runInspect;
   const inspectInput = dependencies.inspect_input;
+  const statusRunner = dependencies.status_runner ?? runStatus;
+  const statusInput = dependencies.status_input;
   const program = new Command();
 
   program.exitOverride();
@@ -76,14 +86,19 @@ Examples:
   $ specforge explain --artifact-file .specforge/task-results/TASK-1.json
     Explain an artifact using deterministic evidence from related inputs.
 
+  $ specforge status --repo iKwesi/SpecForge --pr 123
+    Report pull request state and CI outcomes from GitHub.
+
 Workflow guide:
   1. Run 'specforge doctor' before making changes to confirm your environment is ready.
   2. Run 'specforge inspect' to profile a repository and generate architecture artifacts.
   3. Run 'specforge explain' when you need traceable reasoning for generated artifacts.
+  4. Run 'specforge status' to inspect pull request and CI state after handoff.
 
 Artifacts:
   - 'inspect' writes repository profile and architecture summary artifacts.
   - 'explain' reads one or more artifact files plus optional policy/schedule evidence.
+  - 'status' reads pull request state and status checks from GitHub.
   - 'doctor' reports readiness and exits non-zero when blocking issues are found.
 `
     );
@@ -168,6 +183,36 @@ The command reads artifact inputs and optional policy/schedule context, then pri
         });
 
         stdout.write(formatExplainReport(result));
+      } catch (error) {
+        stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+        throw new CliExitSignal(1);
+      }
+    });
+
+  program
+    .command("status")
+    .description("Report GitHub pull request state and CI outcomes. Example: specforge status --repo iKwesi/SpecForge --pr 123")
+    .requiredOption("--pr <ref>", "Pull request number, URL, or branch to inspect")
+    .option("--repo <owner/repo>", "GitHub repository slug when --pr is not a pull request URL")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ specforge status --repo iKwesi/SpecForge --pr 123
+  $ specforge status --pr https://github.com/iKwesi/SpecForge/pull/123
+
+Use this after PR handoff when you need the latest GitHub merge state and status checks.
+`
+    )
+    .action(async (options: { pr: string; repo?: string }) => {
+      try {
+        const result = await statusRunner({
+          pull_request: options.pr,
+          ...(options.repo ? { repository: options.repo } : {}),
+          ...(statusInput ?? {})
+        });
+
+        stdout.write(formatStatusReport(result));
       } catch (error) {
         stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
         throw new CliExitSignal(1);

--- a/src/core/diagnostics/status.ts
+++ b/src/core/diagnostics/status.ts
@@ -1,0 +1,66 @@
+import {
+  createGitHubProvider,
+  type GetPullRequestStatusInput,
+  type GitHubProvider,
+  type GitHubPullRequestStatus
+} from "../github/provider.js";
+
+export interface RunStatusInput extends GetPullRequestStatusInput {
+  github_provider?: GitHubProvider;
+}
+
+export interface StatusResult {
+  pull_request: GitHubPullRequestStatus;
+}
+
+/**
+ * Report the current GitHub pull request status using the configured provider.
+ *
+ * This stays intentionally narrow for v1: it reads pull request state and status
+ * checks without trying to infer broader run orchestration from GitHub alone.
+ */
+export async function runStatus(input: RunStatusInput): Promise<StatusResult> {
+  const provider = input.github_provider ?? createGitHubProvider();
+  const pullRequest = await provider.getPullRequestStatus({
+    pull_request: input.pull_request,
+    ...(input.repository ? { repository: input.repository } : {})
+  });
+
+  return {
+    pull_request: pullRequest
+  };
+}
+
+export function formatStatusReport(result: StatusResult): string {
+  const lines = [
+    "SpecForge Status",
+    "",
+    `Pull Request: #${result.pull_request.number}`,
+    `URL: ${result.pull_request.url}`,
+    `Title: ${result.pull_request.title}`,
+    `State: ${result.pull_request.state}`,
+    `Merge State: ${result.pull_request.merge_state_status}`,
+    `Overall Status: ${result.pull_request.overall_status}`,
+    `Head Branch: ${result.pull_request.head_branch}`,
+    `Base Branch: ${result.pull_request.base_branch}`,
+    `Linked Issues: ${
+      result.pull_request.linked_issue_numbers.length > 0
+        ? result.pull_request.linked_issue_numbers.map((issueNumber) => `#${issueNumber}`).join(", ")
+        : "none"
+    }`,
+    "",
+    "Status Checks"
+  ];
+
+  if (result.pull_request.status_checks.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const statusCheck of result.pull_request.status_checks) {
+      lines.push(
+        `- ${statusCheck.name} [${statusCheck.type}] ${statusCheck.status}/${statusCheck.conclusion}`
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/src/core/github/provider.ts
+++ b/src/core/github/provider.ts
@@ -1,0 +1,505 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const PR_VIEW_FIELDS = [
+  "number",
+  "url",
+  "title",
+  "state",
+  "mergeStateStatus",
+  "headRefName",
+  "baseRefName",
+  "statusCheckRollup",
+  "closingIssuesReferences"
+] as const;
+const PR_CREATE_VIEW_FIELDS = [
+  "number",
+  "url",
+  "headRefName",
+  "baseRefName",
+  "closingIssuesReferences"
+] as const;
+
+export type GitHubProviderErrorCode =
+  | "provider_unavailable"
+  | "invalid_repository"
+  | "invalid_pull_request"
+  | "command_failed"
+  | "parse_failed";
+
+export class GitHubProviderError extends Error {
+  readonly code: GitHubProviderErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: GitHubProviderErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "GitHubProviderError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface CreatePullRequestInput {
+  repository: string;
+  title: string;
+  body: string;
+  base_branch: string;
+  head_branch: string;
+  linked_issue_numbers?: number[];
+  draft?: boolean;
+}
+
+export interface GitHubPullRequestRef {
+  number: number;
+  url: string;
+  head_branch: string;
+  base_branch: string;
+  linked_issue_numbers: number[];
+}
+
+export type GitHubPullRequestState = "open" | "closed" | "merged";
+export type GitHubMergeStateStatus =
+  | "behind"
+  | "blocked"
+  | "clean"
+  | "dirty"
+  | "draft"
+  | "has_hooks"
+  | "unknown"
+  | "unstable";
+export type GitHubStatusCheckType = "check_run" | "status_context";
+export type GitHubStatusCheckStatus = "completed" | "in_progress" | "pending" | "queued";
+export type GitHubStatusCheckConclusion =
+  | "action_required"
+  | "cancelled"
+  | "failure"
+  | "neutral"
+  | "pending"
+  | "skipped"
+  | "success"
+  | "timed_out"
+  | "unknown";
+export type GitHubOverallStatus = "failure" | "no_checks" | "pending" | "success";
+
+export interface GitHubStatusCheck {
+  name: string;
+  type: GitHubStatusCheckType;
+  status: GitHubStatusCheckStatus;
+  conclusion: GitHubStatusCheckConclusion;
+  workflow_name?: string;
+  details_url?: string;
+}
+
+export interface GitHubPullRequestStatus {
+  number: number;
+  url: string;
+  title: string;
+  state: GitHubPullRequestState;
+  merge_state_status: GitHubMergeStateStatus;
+  head_branch: string;
+  base_branch: string;
+  linked_issue_numbers: number[];
+  overall_status: GitHubOverallStatus;
+  status_checks: GitHubStatusCheck[];
+}
+
+export interface GetPullRequestStatusInput {
+  repository?: string;
+  pull_request: string;
+}
+
+export interface GitHubProvider {
+  isAvailable(): Promise<boolean>;
+  createPullRequest(input: CreatePullRequestInput): Promise<GitHubPullRequestRef>;
+  getPullRequestStatus(input: GetPullRequestStatusInput): Promise<GitHubPullRequestStatus>;
+}
+
+interface ExecResult {
+  stdout: string;
+  stderr: string;
+}
+
+type GitHubExec = (args: string[]) => Promise<ExecResult>;
+
+export function createGitHubProvider(input: {
+  gh_binary?: string;
+  exec?: GitHubExec;
+} = {}): GitHubProvider {
+  const exec = input.exec ?? createGhExec(input.gh_binary ?? "gh");
+  return new GhCliGitHubProvider(exec);
+}
+
+class GhCliGitHubProvider implements GitHubProvider {
+  constructor(private readonly exec: GitHubExec) {}
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await this.exec(["--version"]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async createPullRequest(input: CreatePullRequestInput): Promise<GitHubPullRequestRef> {
+    ensureRepositorySlug(input.repository);
+    ensureNonEmpty(input.title, "title");
+    ensureNonEmpty(input.body, "body");
+    ensureNonEmpty(input.base_branch, "base_branch");
+    ensureNonEmpty(input.head_branch, "head_branch");
+
+    const body = appendIssueLinks(input.body, input.linked_issue_numbers ?? []);
+    const createArgs = [
+      "pr",
+      "create",
+      "--repo",
+      input.repository,
+      "--base",
+      input.base_branch,
+      "--head",
+      input.head_branch,
+      "--title",
+      input.title,
+      "--body",
+      body,
+      ...(input.draft ? ["--draft"] : [])
+    ];
+
+    const created = await runGhCommand(this.exec, createArgs);
+    const url = extractPullRequestUrl(created.stdout);
+    const viewed = await runGhCommand(this.exec, [
+      "pr",
+      "view",
+      url,
+      "--repo",
+      input.repository,
+      "--json",
+      PR_CREATE_VIEW_FIELDS.join(",")
+    ]);
+    const parsed = parseJson(viewed.stdout);
+
+    return {
+      number: readNumber(parsed.number, "pull request number"),
+      url: readString(parsed.url, "pull request url"),
+      head_branch: readString(parsed.headRefName, "head branch"),
+      base_branch: readString(parsed.baseRefName, "base branch"),
+      linked_issue_numbers: readLinkedIssueNumbers(parsed.closingIssuesReferences)
+    };
+  }
+
+  async getPullRequestStatus(input: GetPullRequestStatusInput): Promise<GitHubPullRequestStatus> {
+    if (!isPullRequestUrl(input.pull_request) && !input.repository) {
+      throw new GitHubProviderError(
+        "invalid_repository",
+        "repository is required when pull_request is not a GitHub pull request URL."
+      );
+    }
+
+    if (input.repository) {
+      ensureRepositorySlug(input.repository);
+    }
+
+    ensureNonEmpty(input.pull_request, "pull_request");
+
+    const viewed = await runGhCommand(this.exec, [
+      "pr",
+      "view",
+      input.pull_request,
+      ...(input.repository ? ["--repo", input.repository] : []),
+      "--json",
+      PR_VIEW_FIELDS.join(",")
+    ]);
+    const parsed = parseJson(viewed.stdout);
+    const statusChecks = readStatusChecks(parsed.statusCheckRollup);
+
+    return {
+      number: readNumber(parsed.number, "pull request number"),
+      url: readString(parsed.url, "pull request url"),
+      title: readString(parsed.title, "pull request title"),
+      state: normalizePullRequestState(parsed.state),
+      merge_state_status: normalizeMergeStateStatus(parsed.mergeStateStatus),
+      head_branch: readString(parsed.headRefName, "head branch"),
+      base_branch: readString(parsed.baseRefName, "base branch"),
+      linked_issue_numbers: readLinkedIssueNumbers(parsed.closingIssuesReferences),
+      overall_status: deriveOverallStatus(statusChecks),
+      status_checks: statusChecks
+    };
+  }
+}
+
+function createGhExec(ghBinary: string): GitHubExec {
+  return async (args) => {
+    try {
+      const result = await execFileAsync(ghBinary, args, { encoding: "utf8" });
+      return {
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? ""
+      };
+    } catch (error) {
+      const details = error as NodeJS.ErrnoException & { stdout?: string; stderr?: string };
+      if (details.code === "ENOENT") {
+        throw new GitHubProviderError(
+          "provider_unavailable",
+          `GitHub CLI was not found at ${ghBinary}.`,
+          error
+        );
+      }
+
+      throw new GitHubProviderError(
+        "command_failed",
+        `GitHub CLI command failed: ${[ghBinary, ...args].join(" ")}`,
+        {
+          message: details.message,
+          stdout: details.stdout,
+          stderr: details.stderr
+        }
+      );
+    }
+  };
+}
+
+async function runGhCommand(exec: GitHubExec, args: string[]): Promise<ExecResult> {
+  return await exec(args);
+}
+
+function ensureRepositorySlug(repository: string): void {
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository.trim())) {
+    throw new GitHubProviderError(
+      "invalid_repository",
+      `repository must use OWNER/REPO format: ${repository}`
+    );
+  }
+}
+
+function ensureNonEmpty(value: string, field: string): void {
+  if (value.trim().length === 0) {
+    throw new GitHubProviderError("invalid_pull_request", `${field} must be non-empty.`);
+  }
+}
+
+function appendIssueLinks(body: string, linkedIssueNumbers: number[]): string {
+  if (linkedIssueNumbers.length === 0) {
+    return body;
+  }
+
+  const lines = linkedIssueNumbers.map((issueNumber) => `Closes #${issueNumber}`);
+  return `${body}\n\n${lines.join("\n")}`;
+}
+
+function extractPullRequestUrl(stdout: string): string {
+  const url = stdout
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .find((token) => token.startsWith("https://github.com/") && token.includes("/pull/"));
+
+  if (!url) {
+    throw new GitHubProviderError(
+      "parse_failed",
+      "GitHub CLI did not return a pull request URL after creation."
+    );
+  }
+
+  return url;
+}
+
+function parseJson(stdout: string): Record<string, unknown> {
+  try {
+    return JSON.parse(stdout) as Record<string, unknown>;
+  } catch (error) {
+    throw new GitHubProviderError("parse_failed", "Failed to parse GitHub CLI JSON output.", error);
+  }
+}
+
+function readNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new GitHubProviderError("parse_failed", `GitHub CLI returned invalid ${field}.`);
+  }
+
+  return value;
+}
+
+function readString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new GitHubProviderError("parse_failed", `GitHub CLI returned invalid ${field}.`);
+  }
+
+  return value;
+}
+
+function readLinkedIssueNumbers(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => (entry as { number?: unknown }).number)
+    .filter((entry): entry is number => typeof entry === "number" && Number.isInteger(entry) && entry > 0)
+    .sort((left, right) => left - right);
+}
+
+function readStatusChecks(value: unknown): GitHubStatusCheck[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => mapStatusCheck(entry))
+    .filter((entry): entry is GitHubStatusCheck => entry !== undefined);
+}
+
+function mapStatusCheck(value: unknown): GitHubStatusCheck | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const entry = value as Record<string, unknown>;
+  const typename = readOptionalString(entry.__typename);
+
+  if (typename === "StatusContext") {
+    const name = readOptionalString(entry.context);
+    if (!name) {
+      return undefined;
+    }
+
+    const conclusion = normalizeStatusContextConclusion(readOptionalString(entry.state));
+    const detailsUrl = readOptionalString(entry.targetUrl);
+    return {
+      name,
+      type: "status_context",
+      status: conclusion === "pending" ? "pending" : "completed",
+      conclusion,
+      ...(detailsUrl ? { details_url: detailsUrl } : {})
+    };
+  }
+
+  const name = readOptionalString(entry.name);
+  if (!name) {
+    return undefined;
+  }
+
+  const workflowName = readOptionalString(entry.workflowName);
+  const detailsUrl = readOptionalString(entry.detailsUrl);
+
+  return {
+    name,
+    type: "check_run",
+    status: normalizeCheckStatus(readOptionalString(entry.status)),
+    conclusion: normalizeCheckConclusion(
+      readOptionalString(entry.conclusion),
+      readOptionalString(entry.status)
+    ),
+    ...(workflowName ? { workflow_name: workflowName } : {}),
+    ...(detailsUrl ? { details_url: detailsUrl } : {})
+  };
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function normalizePullRequestState(value: unknown): GitHubPullRequestState {
+  switch (readString(value, "pull request state").toLowerCase()) {
+    case "open":
+      return "open";
+    case "closed":
+      return "closed";
+    case "merged":
+      return "merged";
+    default:
+      throw new GitHubProviderError("parse_failed", "GitHub CLI returned an unknown pull request state.");
+  }
+}
+
+function normalizeMergeStateStatus(value: unknown): GitHubMergeStateStatus {
+  const normalized = readString(value, "merge state status").toLowerCase();
+  switch (normalized) {
+    case "behind":
+    case "blocked":
+    case "clean":
+    case "dirty":
+    case "draft":
+    case "has_hooks":
+    case "unknown":
+    case "unstable":
+      return normalized;
+    default:
+      return "unknown";
+  }
+}
+
+function normalizeCheckStatus(value: string | undefined): GitHubStatusCheckStatus {
+  switch ((value ?? "").toLowerCase()) {
+    case "completed":
+      return "completed";
+    case "in_progress":
+      return "in_progress";
+    case "queued":
+      return "queued";
+    default:
+      return "pending";
+  }
+}
+
+function normalizeCheckConclusion(
+  conclusion: string | undefined,
+  status: string | undefined
+): GitHubStatusCheckConclusion {
+  if ((status ?? "").toLowerCase() !== "completed") {
+    return "pending";
+  }
+
+  switch ((conclusion ?? "").toLowerCase()) {
+    case "action_required":
+    case "cancelled":
+    case "failure":
+    case "neutral":
+    case "skipped":
+    case "success":
+    case "timed_out":
+      return conclusion!.toLowerCase() as GitHubStatusCheckConclusion;
+    default:
+      return "unknown";
+  }
+}
+
+function normalizeStatusContextConclusion(value: string | undefined): GitHubStatusCheckConclusion {
+  switch ((value ?? "").toLowerCase()) {
+    case "success":
+      return "success";
+    case "failure":
+    case "error":
+      return "failure";
+    case "pending":
+    case "expected":
+      return "pending";
+    default:
+      return "unknown";
+  }
+}
+
+function deriveOverallStatus(statusChecks: GitHubStatusCheck[]): GitHubOverallStatus {
+  if (statusChecks.length === 0) {
+    return "no_checks";
+  }
+
+  if (
+    statusChecks.some((check) =>
+      ["failure", "timed_out", "cancelled", "action_required", "unknown"].includes(
+        check.conclusion
+      )
+    )
+  ) {
+    return "failure";
+  }
+
+  if (statusChecks.some((check) => check.conclusion === "pending" || check.status !== "completed")) {
+    return "pending";
+  }
+
+  return "success";
+}
+
+function isPullRequestUrl(value: string): boolean {
+  return /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/.test(value.trim());
+}

--- a/tests/cli/status-command.test.ts
+++ b/tests/cli/status-command.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { runCli } from "../../src/cli.js";
+import type { StatusResult } from "../../src/core/diagnostics/status.js";
+
+function buildStatusResult(): StatusResult {
+  return {
+    pull_request: {
+      number: 123,
+      url: "https://github.com/iKwesi/SpecForge/pull/123",
+      title: "feat: implement task flow",
+      state: "open",
+      merge_state_status: "clean",
+      head_branch: "feat/task-1",
+      base_branch: "main",
+      linked_issue_numbers: [40],
+      overall_status: "success",
+      status_checks: [
+        {
+          name: "build",
+          type: "check_run",
+          status: "completed",
+          conclusion: "success",
+          workflow_name: "ci",
+          details_url: "https://example.com/build"
+        }
+      ]
+    }
+  };
+}
+
+describe("sf status command", () => {
+  it("prints pull request status details and exits cleanly", async () => {
+    let stdout = "";
+    let receivedInput: { repository?: string; pull_request?: string } | undefined;
+
+    const exitCode = await runCli(["node", "sf", "status", "--repo", "iKwesi/SpecForge", "--pr", "123"], {
+      stdout: {
+        write(chunk: string) {
+          stdout += chunk;
+          return true;
+        }
+      },
+      status_runner: async (input) => {
+        receivedInput = input;
+        return buildStatusResult();
+      }
+    });
+
+    expect(exitCode).toBe(0);
+    expect(receivedInput).toEqual({
+      repository: "iKwesi/SpecForge",
+      pull_request: "123"
+    });
+    expect(stdout).toContain("SpecForge Status");
+    expect(stdout).toContain("Pull Request: #123");
+  });
+
+  it("returns exit code 1 when the status command fails", async () => {
+    let stderr = "";
+
+    const exitCode = await runCli(["node", "sf", "status", "--pr", "123"], {
+      stderr: {
+        write(chunk: string) {
+          stderr += chunk;
+          return true;
+        }
+      },
+      status_runner: async () => {
+        throw new Error("status failed");
+      }
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("status failed");
+  });
+});

--- a/tests/diagnostics/status.test.ts
+++ b/tests/diagnostics/status.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { formatStatusReport, runStatus } from "../../src/core/diagnostics/status.js";
+
+describe("runStatus", () => {
+  it("renders a deterministic PR status report", async () => {
+    const result = await runStatus({
+      repository: "iKwesi/SpecForge",
+      pull_request: "123",
+      github_provider: {
+        async isAvailable() {
+          return true;
+        },
+        async createPullRequest() {
+          throw new Error("not used");
+        },
+        async getPullRequestStatus() {
+          return {
+            number: 123,
+            url: "https://github.com/iKwesi/SpecForge/pull/123",
+            title: "feat: implement task flow",
+            state: "open",
+            merge_state_status: "clean",
+            head_branch: "feat/task-1",
+            base_branch: "main",
+            linked_issue_numbers: [40],
+            overall_status: "failure",
+            status_checks: [
+              {
+                name: "build",
+                type: "check_run",
+                status: "completed",
+                conclusion: "success",
+                workflow_name: "ci",
+                details_url: "https://example.com/build"
+              },
+              {
+                name: "policy",
+                type: "check_run",
+                status: "completed",
+                conclusion: "failure",
+                workflow_name: "ci",
+                details_url: "https://example.com/policy"
+              }
+            ]
+          };
+        }
+      }
+    });
+
+    expect(result.pull_request.number).toBe(123);
+    expect(result.pull_request.overall_status).toBe("failure");
+
+    const report = formatStatusReport(result);
+    expect(report).toContain("SpecForge Status");
+    expect(report).toContain("Pull Request: #123");
+    expect(report).toContain("Overall Status: failure");
+    expect(report).toContain("Linked Issues: #40");
+    expect(report).toContain("- policy [check_run] completed/failure");
+  });
+});

--- a/tests/github/provider.test.ts
+++ b/tests/github/provider.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GitHubProviderError,
+  createGitHubProvider
+} from "../../src/core/github/provider.js";
+
+describe("github provider createPullRequest", () => {
+  it("creates a pull request, appends issue linkage, and returns linked issues", async () => {
+    const calls: string[][] = [];
+    const provider = createGitHubProvider({
+      exec: async (args) => {
+        calls.push(args);
+
+        if (args[0] === "pr" && args[1] === "create") {
+          return {
+            stdout: "https://github.com/iKwesi/SpecForge/pull/123\n",
+            stderr: ""
+          };
+        }
+
+        if (args[0] === "pr" && args[1] === "view") {
+          return {
+            stdout: JSON.stringify({
+              number: 123,
+              url: "https://github.com/iKwesi/SpecForge/pull/123",
+              headRefName: "feat/task-1",
+              baseRefName: "main",
+              closingIssuesReferences: [{ number: 40 }, { number: 41 }]
+            }),
+            stderr: ""
+          };
+        }
+
+        throw new Error(`Unexpected gh args: ${args.join(" ")}`);
+      }
+    });
+
+    const result = await provider.createPullRequest({
+      repository: "iKwesi/SpecForge",
+      title: "feat: implement task flow",
+      body: "## Summary\n- complete the task",
+      base_branch: "main",
+      head_branch: "feat/task-1",
+      linked_issue_numbers: [40, 41]
+    });
+
+    expect(result.number).toBe(123);
+    expect(result.url).toBe("https://github.com/iKwesi/SpecForge/pull/123");
+    expect(result.linked_issue_numbers).toEqual([40, 41]);
+    expect(calls[0]).toEqual([
+      "pr",
+      "create",
+      "--repo",
+      "iKwesi/SpecForge",
+      "--base",
+      "main",
+      "--head",
+      "feat/task-1",
+      "--title",
+      "feat: implement task flow",
+      "--body",
+      "## Summary\n- complete the task\n\nCloses #40\nCloses #41"
+    ]);
+    expect(calls[1]).toEqual([
+      "pr",
+      "view",
+      "https://github.com/iKwesi/SpecForge/pull/123",
+      "--repo",
+      "iKwesi/SpecForge",
+      "--json",
+      "number,url,headRefName,baseRefName,closingIssuesReferences"
+    ]);
+  });
+
+  it("fails with a typed error when repository format is invalid", async () => {
+    const provider = createGitHubProvider({
+      exec: async () => ({ stdout: "", stderr: "" })
+    });
+
+    await expect(
+      provider.createPullRequest({
+        repository: "bad",
+        title: "feat: implement task flow",
+        body: "summary",
+        base_branch: "main",
+        head_branch: "feat/task-1"
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<GitHubProviderError>>({
+        code: "invalid_repository"
+      })
+    );
+  });
+});
+
+describe("github provider getPullRequestStatus", () => {
+  it("maps GitHub status checks into a deterministic status report", async () => {
+    const provider = createGitHubProvider({
+      exec: async (args) => {
+        expect(args).toEqual([
+          "pr",
+          "view",
+          "123",
+          "--repo",
+          "iKwesi/SpecForge",
+          "--json",
+          "number,url,title,state,mergeStateStatus,headRefName,baseRefName,statusCheckRollup,closingIssuesReferences"
+        ]);
+
+        return {
+          stdout: JSON.stringify({
+            number: 123,
+            url: "https://github.com/iKwesi/SpecForge/pull/123",
+            title: "feat: implement task flow",
+            state: "OPEN",
+            mergeStateStatus: "CLEAN",
+            headRefName: "feat/task-1",
+            baseRefName: "main",
+            closingIssuesReferences: [{ number: 40 }],
+            statusCheckRollup: [
+              {
+                __typename: "CheckRun",
+                name: "build",
+                status: "COMPLETED",
+                conclusion: "SUCCESS",
+                workflowName: "ci",
+                detailsUrl: "https://example.com/build"
+              },
+              {
+                __typename: "CheckRun",
+                name: "test",
+                status: "IN_PROGRESS",
+                conclusion: "",
+                workflowName: "ci",
+                detailsUrl: "https://example.com/test"
+              }
+            ]
+          }),
+          stderr: ""
+        };
+      }
+    });
+
+    const result = await provider.getPullRequestStatus({
+      repository: "iKwesi/SpecForge",
+      pull_request: "123"
+    });
+
+    expect(result.number).toBe(123);
+    expect(result.overall_status).toBe("pending");
+    expect(result.linked_issue_numbers).toEqual([40]);
+    expect(result.status_checks).toEqual([
+      {
+        name: "build",
+        type: "check_run",
+        status: "completed",
+        conclusion: "success",
+        workflow_name: "ci",
+        details_url: "https://example.com/build"
+      },
+      {
+        name: "test",
+        type: "check_run",
+        status: "in_progress",
+        conclusion: "pending",
+        workflow_name: "ci",
+        details_url: "https://example.com/test"
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a GitHub provider around gh for pull request creation, issue linkage, and status retrieval
- add runStatus/formatStatusReport and wire a real sf status command into the CLI
- cover provider behavior, status formatting, and CLI status output with tests

## Testing
- pnpm test
- pnpm typecheck
- pnpm build

Closes #33