### PR TITLE
feat: extract policy enforcement boundary

### DIFF
--- a/src/core/contracts/policy.ts
+++ b/src/core/contracts/policy.ts
@@ -24,9 +24,29 @@ export interface SpecForgePolicyConfig {
   gates: GatePolicy;
 }
 
+export type PolicyValidationReasonCode =
+  | "invalid_policy_object"
+  | "missing_coverage"
+  | "invalid_coverage_scope"
+  | "invalid_coverage_enforcement"
+  | "missing_parallelism"
+  | "invalid_parallelism_max_concurrent_tasks"
+  | "invalid_parallelism_serialize_on_uncertainty"
+  | "missing_gates"
+  | "missing_enabled_gates"
+  | "unknown_enabled_gate_key"
+  | "missing_enabled_gate_key"
+  | "invalid_enabled_gate_type"
+  | "missing_applicable_project_modes"
+  | "invalid_applicable_project_modes_shape"
+  | "unknown_applicable_project_modes_gate"
+  | "invalid_applicable_project_modes_type"
+  | "invalid_project_mode";
+
 export interface PolicyValidationIssue {
   path: string;
   message: string;
+  reason_code: PolicyValidationReasonCode;
 }
 
 export interface PolicyValidationResult {
@@ -92,7 +112,8 @@ export function validatePolicyConfig(candidate: unknown): PolicyValidationResult
       issues: [
         {
           path: "$",
-          message: "must be a JSON object."
+          message: "must be a JSON object.",
+          reason_code: "invalid_policy_object"
         }
       ]
     };
@@ -113,7 +134,8 @@ function validateCoveragePolicy(candidate: unknown, issues: PolicyValidationIssu
   if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
     issues.push({
       path: "coverage",
-      message: "must be an object with scope and enforcement."
+      message: "must be an object with scope and enforcement.",
+      reason_code: "missing_coverage"
     });
     return;
   }
@@ -122,14 +144,16 @@ function validateCoveragePolicy(candidate: unknown, issues: PolicyValidationIssu
   if (coverage.scope !== "changed-lines") {
     issues.push({
       path: "coverage.scope",
-      message: "must be \"changed-lines\"."
+      message: "must be \"changed-lines\".",
+      reason_code: "invalid_coverage_scope"
     });
   }
 
   if (coverage.enforcement !== "report-only" && coverage.enforcement !== "hard-block") {
     issues.push({
       path: "coverage.enforcement",
-      message: "must be \"report-only\" or \"hard-block\"."
+      message: "must be \"report-only\" or \"hard-block\".",
+      reason_code: "invalid_coverage_enforcement"
     });
   }
 }
@@ -138,7 +162,8 @@ function validateParallelismPolicy(candidate: unknown, issues: PolicyValidationI
   if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
     issues.push({
       path: "parallelism",
-      message: "must be an object with max_concurrent_tasks and serialize_on_uncertainty."
+      message: "must be an object with max_concurrent_tasks and serialize_on_uncertainty.",
+      reason_code: "missing_parallelism"
     });
     return;
   }
@@ -150,14 +175,16 @@ function validateParallelismPolicy(candidate: unknown, issues: PolicyValidationI
   ) {
     issues.push({
       path: "parallelism.max_concurrent_tasks",
-      message: "must be a positive integer."
+      message: "must be a positive integer.",
+      reason_code: "invalid_parallelism_max_concurrent_tasks"
     });
   }
 
   if (typeof parallelism.serialize_on_uncertainty !== "boolean") {
     issues.push({
       path: "parallelism.serialize_on_uncertainty",
-      message: "must be a boolean."
+      message: "must be a boolean.",
+      reason_code: "invalid_parallelism_serialize_on_uncertainty"
     });
   }
 }
@@ -166,7 +193,8 @@ function validateGatePolicy(candidate: unknown, issues: PolicyValidationIssue[])
   if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
     issues.push({
       path: "gates",
-      message: "must be an object with enabled_by_default and applicable_project_modes."
+      message: "must be an object with enabled_by_default and applicable_project_modes.",
+      reason_code: "missing_gates"
     });
     return;
   }
@@ -183,7 +211,8 @@ function validateEnabledGates(
   if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
     issues.push({
       path: "gates.enabled_by_default",
-      message: "must be an object keyed by known gate names."
+      message: "must be an object keyed by known gate names.",
+      reason_code: "missing_enabled_gates"
     });
     return;
   }
@@ -193,7 +222,8 @@ function validateEnabledGates(
     if (!isKnownGate(gate)) {
       issues.push({
         path: `gates.enabled_by_default.${gate}`,
-        message: "must use a known artifact gate key."
+        message: "must use a known artifact gate key.",
+        reason_code: "unknown_enabled_gate_key"
       });
     }
   }
@@ -203,7 +233,8 @@ function validateEnabledGates(
     if (value === undefined) {
       issues.push({
         path: `gates.enabled_by_default.${gate}`,
-        message: "is required and must be a boolean."
+        message: "is required and must be a boolean.",
+        reason_code: "missing_enabled_gate_key"
       });
       continue;
     }
@@ -211,7 +242,8 @@ function validateEnabledGates(
     if (typeof value !== "boolean") {
       issues.push({
         path: `gates.enabled_by_default.${gate}`,
-        message: "must be a boolean."
+        message: "must be a boolean.",
+        reason_code: "invalid_enabled_gate_type"
       });
     }
   }
@@ -224,7 +256,8 @@ function validateApplicableProjectModes(
   if (candidate === undefined) {
     issues.push({
       path: "gates.applicable_project_modes",
-      message: "must be an object keyed by gate name to arrays of supported project modes."
+      message: "must be an object keyed by gate name to arrays of supported project modes.",
+      reason_code: "missing_applicable_project_modes"
     });
     return;
   }
@@ -232,7 +265,8 @@ function validateApplicableProjectModes(
   if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
     issues.push({
       path: "gates.applicable_project_modes",
-      message: "must be an object keyed by gate name to arrays of supported project modes."
+      message: "must be an object keyed by gate name to arrays of supported project modes.",
+      reason_code: "invalid_applicable_project_modes_shape"
     });
     return;
   }
@@ -243,7 +277,8 @@ function validateApplicableProjectModes(
     if (!isKnownGate(gate)) {
       issues.push({
         path: `gates.applicable_project_modes.${gate}`,
-        message: "must use a known artifact gate key."
+        message: "must use a known artifact gate key.",
+        reason_code: "unknown_applicable_project_modes_gate"
       });
       continue;
     }
@@ -251,7 +286,8 @@ function validateApplicableProjectModes(
     if (!Array.isArray(modes)) {
       issues.push({
         path: `gates.applicable_project_modes.${gate}`,
-        message: "must be an array of supported project modes."
+        message: "must be an array of supported project modes.",
+        reason_code: "invalid_applicable_project_modes_type"
       });
       continue;
     }
@@ -260,7 +296,8 @@ function validateApplicableProjectModes(
       if (!PROJECT_MODES.includes(mode as ProjectMode)) {
         issues.push({
           path: `gates.applicable_project_modes.${gate}[${index}]`,
-          message: `must be one of ${allowedModesDescription}.`
+          message: `must be one of ${allowedModesDescription}.`,
+          reason_code: "invalid_project_mode"
         });
       }
     }

--- a/src/core/diagnostics/ciPolicy.ts
+++ b/src/core/diagnostics/ciPolicy.ts
@@ -1,5 +1,8 @@
-import { ARTIFACT_GATES, PROJECT_MODES } from "../contracts/domain.js";
 import type { SpecForgePolicyConfig } from "../contracts/policy.js";
+import {
+  evaluateBootstrapPolicyChecks,
+  type PolicyEnforcementReasonCode
+} from "../policy/enforcement.js";
 
 export type CiPolicyStatus = "pass" | "fail";
 
@@ -8,6 +11,7 @@ export interface CiPolicyCheck {
   status: CiPolicyStatus;
   message: string;
   remediation?: string;
+  reason_codes: PolicyEnforcementReasonCode[];
 }
 
 export interface CiPolicyCheckSummary {
@@ -28,11 +32,13 @@ export interface CiPolicyCheckResult {
  * not because the checker invents new enforcement rules beyond the current contract.
  */
 export function runCiPolicyCheck(policy: SpecForgePolicyConfig): CiPolicyCheckResult {
-  const checks: CiPolicyCheck[] = [
-    validateCoveragePolicy(policy),
-    validateParallelismPolicy(policy),
-    validateGatePolicy(policy)
-  ];
+  const checks: CiPolicyCheck[] = evaluateBootstrapPolicyChecks(policy).map((check) => ({
+    id: check.id,
+    status: check.status,
+    message: check.message,
+    ...(check.remediation ? { remediation: check.remediation } : {}),
+    reason_codes: check.reason_codes
+  }));
 
   const summary = {
     passed: checks.filter((check) => check.status === "pass").length,
@@ -61,73 +67,4 @@ export function formatCiPolicyReport(result: CiPolicyCheckResult): string {
   lines.push(`Overall: ${result.overall_status.toUpperCase()}`);
 
   return `${lines.join("\n")}\n`;
-}
-
-function validateCoveragePolicy(policy: SpecForgePolicyConfig): CiPolicyCheck {
-  const valid =
-    policy.coverage.scope === "changed-lines" &&
-    (policy.coverage.enforcement === "report-only" || policy.coverage.enforcement === "hard-block");
-
-  if (!valid) {
-    return {
-      id: "coverage_policy",
-      status: "fail",
-      message: "Coverage policy must keep changed-lines scope with report-only or hard-block enforcement.",
-      remediation: "Restore coverage.scope=changed-lines and a supported enforcement mode."
-    };
-  }
-
-  return {
-    id: "coverage_policy",
-    status: "pass",
-    message: `Coverage policy is ${policy.coverage.scope}/${policy.coverage.enforcement}.`
-  };
-}
-
-function validateParallelismPolicy(policy: SpecForgePolicyConfig): CiPolicyCheck {
-  const valid =
-    Number.isInteger(policy.parallelism.max_concurrent_tasks) &&
-    policy.parallelism.max_concurrent_tasks > 0 &&
-    typeof policy.parallelism.serialize_on_uncertainty === "boolean";
-
-  if (!valid) {
-    return {
-      id: "parallelism_policy",
-      status: "fail",
-      message: "Parallelism policy must define a positive max_concurrent_tasks and boolean serialize_on_uncertainty.",
-      remediation: "Restore a valid parallelism policy shape before merging."
-    };
-  }
-
-  return {
-    id: "parallelism_policy",
-    status: "pass",
-    message: `Parallelism policy is max=${policy.parallelism.max_concurrent_tasks}, serialize_on_uncertainty=${policy.parallelism.serialize_on_uncertainty}.`
-  };
-}
-
-function validateGatePolicy(policy: SpecForgePolicyConfig): CiPolicyCheck {
-  const gateKeys = Object.keys(policy.gates.enabled_by_default);
-  const enabledDefaultsValid =
-    gateKeys.length === ARTIFACT_GATES.length &&
-    ARTIFACT_GATES.every((gate) => typeof policy.gates.enabled_by_default[gate] === "boolean");
-
-  const applicableModesValid = Object.values(policy.gates.applicable_project_modes).every((modes) =>
-    (modes ?? []).every((mode) => PROJECT_MODES.includes(mode))
-  );
-
-  if (!enabledDefaultsValid || !applicableModesValid) {
-    return {
-      id: "gate_policy",
-      status: "fail",
-      message: "Gate policy must cover known gates and only reference supported project modes.",
-      remediation: "Restore gate defaults and applicable project modes to the known v1 contract."
-    };
-  }
-
-  return {
-    id: "gate_policy",
-    status: "pass",
-    message: "Gate policy covers the known artifact gates and supported project modes."
-  };
 }

--- a/src/core/diagnostics/doctor.ts
+++ b/src/core/diagnostics/doctor.ts
@@ -3,10 +3,12 @@ import { promisify } from "node:util";
 
 import {
   createDefaultPolicyConfig,
-  formatPolicyValidationIssues,
-  validatePolicyConfig,
   type SpecForgePolicyConfig
 } from "../contracts/policy.js";
+import {
+  evaluatePolicyConfigCheck,
+  type PolicyEnforcementReasonCode
+} from "../policy/enforcement.js";
 
 const execFileAsync = promisify(execFile);
 const MINIMUM_NODE_MAJOR = 22;
@@ -19,6 +21,7 @@ export interface DoctorCheck {
   status: DoctorStatus;
   message: string;
   remediation?: string;
+  reason_codes?: PolicyEnforcementReasonCode[];
 }
 
 export interface DoctorSummary {
@@ -211,25 +214,15 @@ async function checkRepositoryRoot(input: {
 }
 
 function checkPolicyConfig(policy: SpecForgePolicyConfig): DoctorCheck {
-  const validation = validatePolicyConfig(policy);
-  if (!validation.valid) {
-    const issueSummary = formatPolicyValidationIssues(validation.issues);
-
-    return {
-      id: "policy_config",
-      label: "Policy config",
-      status: "fail",
-      message: `Policy configuration is invalid: ${issueSummary}`,
-      remediation:
-        "Update the policy config to match docs/POLICY_CONFIG.md or docs/examples/specforge.policy.example.json."
-    };
-  }
+  const result = evaluatePolicyConfigCheck(policy);
 
   return {
-    id: "policy_config",
+    id: result.id,
     label: "Policy config",
-    status: "pass",
-    message: "Policy configuration is valid for the current v1 contract."
+    status: result.status,
+    message: result.message,
+    ...(result.remediation ? { remediation: result.remediation } : {}),
+    reason_codes: result.reason_codes
   };
 }
 

--- a/src/core/diagnostics/explain.ts
+++ b/src/core/diagnostics/explain.ts
@@ -1,12 +1,9 @@
 import { readFile } from "node:fs/promises";
 
 import { ARTIFACT_GATES } from "../contracts/domain.js";
-import {
-  formatPolicyValidationIssues,
-  validatePolicyConfig,
-  type SpecForgePolicyConfig
-} from "../contracts/policy.js";
+import { type SpecForgePolicyConfig } from "../contracts/policy.js";
 import type { ConservativeSchedule, ConservativeScheduleBatch } from "../execution/scheduler.js";
+import { evaluatePolicyConfigCheck } from "../policy/enforcement.js";
 
 export type ExplainErrorCode =
   | "missing_artifact_input"
@@ -200,12 +197,12 @@ async function readArtifactEvidence(path: string): Promise<ExplainArtifactEviden
 
 async function readPolicyEvidence(path: string): Promise<ExplainPolicyEvidence> {
   const value = await readJsonFile(path, "policy_read_failed");
-  const validation = validatePolicyConfig(value);
-  if (!validation.valid) {
+  const policyCheck = evaluatePolicyConfigCheck(value);
+  if (policyCheck.status === "fail") {
     throw new ExplainError(
       "invalid_policy",
-      `Invalid policy file: ${path}. ${formatPolicyValidationIssues(validation.issues)}`,
-      validation.issues
+      `Invalid policy file: ${path}. ${policyCheck.message.replace(/^Policy configuration is invalid: /, "")}`,
+      policyCheck.issues
     );
   }
   const policy = value as SpecForgePolicyConfig;

--- a/src/core/policy/enforcement.ts
+++ b/src/core/policy/enforcement.ts
@@ -1,0 +1,201 @@
+import {
+  formatPolicyValidationIssues,
+  validatePolicyConfig,
+  type PolicyValidationIssue,
+  type PolicyValidationReasonCode
+} from "../contracts/policy.js";
+
+export type PolicyEnforcementCheckId =
+  | "policy_config"
+  | "coverage_policy"
+  | "parallelism_policy"
+  | "gate_policy";
+
+export type PolicyEnforcementStatus = "pass" | "fail";
+
+export type PolicyEnforcementReasonCode =
+  | PolicyValidationReasonCode
+  | "policy_config_valid"
+  | "coverage_supported"
+  | "parallelism_supported"
+  | "gate_policy_supported";
+
+export interface PolicyEnforcementCheck {
+  id: PolicyEnforcementCheckId;
+  status: PolicyEnforcementStatus;
+  message: string;
+  remediation?: string;
+  reason_codes: PolicyEnforcementReasonCode[];
+  issues?: PolicyValidationIssue[];
+}
+
+const GLOBAL_POLICY_REASON_CODES = new Set<PolicyValidationReasonCode>(["invalid_policy_object"]);
+const COVERAGE_REASON_CODES = new Set<PolicyValidationReasonCode>([
+  "missing_coverage",
+  "invalid_coverage_scope",
+  "invalid_coverage_enforcement"
+]);
+const PARALLELISM_REASON_CODES = new Set<PolicyValidationReasonCode>([
+  "missing_parallelism",
+  "invalid_parallelism_max_concurrent_tasks",
+  "invalid_parallelism_serialize_on_uncertainty"
+]);
+const GATE_REASON_CODES = new Set<PolicyValidationReasonCode>([
+  "missing_gates",
+  "missing_enabled_gates",
+  "unknown_enabled_gate_key",
+  "missing_enabled_gate_key",
+  "invalid_enabled_gate_type",
+  "missing_applicable_project_modes",
+  "invalid_applicable_project_modes_shape",
+  "unknown_applicable_project_modes_gate",
+  "invalid_applicable_project_modes_type",
+  "invalid_project_mode"
+]);
+
+/**
+ * Evaluate the full policy config contract once and return a deterministic
+ * result that downstream diagnostics can reuse without re-encoding rules.
+ */
+export function evaluatePolicyConfigCheck(policy: unknown): PolicyEnforcementCheck {
+  const validation = validatePolicyConfig(policy);
+  if (!validation.valid) {
+    return {
+      id: "policy_config",
+      status: "fail",
+      message: `Policy configuration is invalid: ${formatPolicyValidationIssues(validation.issues)}`,
+      remediation:
+        "Update the policy config to match docs/POLICY_CONFIG.md or docs/examples/specforge.policy.example.json.",
+      reason_codes: collectIssueReasonCodes(validation.issues),
+      issues: validation.issues
+    };
+  }
+
+  return {
+    id: "policy_config",
+    status: "pass",
+    message: "Policy configuration is valid for the current v1 contract.",
+    reason_codes: ["policy_config_valid"]
+  };
+}
+
+/**
+ * Evaluate the narrow bootstrap policy invariants used by CI and other
+ * safety gates. These checks stay intentionally scoped to the current v1
+ * support contract instead of inventing broader policy semantics.
+ */
+export function evaluateBootstrapPolicyChecks(policy: unknown): PolicyEnforcementCheck[] {
+  const validation = validatePolicyConfig(policy);
+
+  return [
+    buildCoverageCheck(policy, validation.issues),
+    buildParallelismCheck(policy, validation.issues),
+    buildGateCheck(validation.issues)
+  ];
+}
+
+function buildCoverageCheck(policy: unknown, issues: PolicyValidationIssue[]): PolicyEnforcementCheck {
+  const relevantIssues = selectIssues(issues, COVERAGE_REASON_CODES);
+  if (relevantIssues.length > 0) {
+    return {
+      id: "coverage_policy",
+      status: "fail",
+      message: "Coverage policy must keep changed-lines scope with report-only or hard-block enforcement.",
+      remediation: "Restore coverage.scope=changed-lines and a supported enforcement mode.",
+      reason_codes: collectIssueReasonCodes(relevantIssues),
+      issues: relevantIssues
+    };
+  }
+
+  const coverageDescription = describeCoveragePolicy(policy);
+  return {
+    id: "coverage_policy",
+    status: "pass",
+    message: `Coverage policy is ${coverageDescription}.`,
+    reason_codes: ["coverage_supported"]
+  };
+}
+
+function buildParallelismCheck(
+  policy: unknown,
+  issues: PolicyValidationIssue[]
+): PolicyEnforcementCheck {
+  const relevantIssues = selectIssues(issues, PARALLELISM_REASON_CODES);
+  if (relevantIssues.length > 0) {
+    return {
+      id: "parallelism_policy",
+      status: "fail",
+      message: "Parallelism policy must define a positive max_concurrent_tasks and boolean serialize_on_uncertainty.",
+      remediation: "Restore a valid parallelism policy shape before merging.",
+      reason_codes: collectIssueReasonCodes(relevantIssues),
+      issues: relevantIssues
+    };
+  }
+
+  const parallelismDescription = describeParallelismPolicy(policy);
+  return {
+    id: "parallelism_policy",
+    status: "pass",
+    message: `Parallelism policy is ${parallelismDescription}.`,
+    reason_codes: ["parallelism_supported"]
+  };
+}
+
+function buildGateCheck(issues: PolicyValidationIssue[]): PolicyEnforcementCheck {
+  const relevantIssues = selectIssues(issues, GATE_REASON_CODES);
+  if (relevantIssues.length > 0) {
+    return {
+      id: "gate_policy",
+      status: "fail",
+      message: "Gate policy must cover known gates and only reference supported project modes.",
+      remediation: "Restore gate defaults and applicable project modes to the known v1 contract.",
+      reason_codes: collectIssueReasonCodes(relevantIssues),
+      issues: relevantIssues
+    };
+  }
+
+  return {
+    id: "gate_policy",
+    status: "pass",
+    message: "Gate policy covers the known artifact gates and supported project modes.",
+    reason_codes: ["gate_policy_supported"]
+  };
+}
+
+function selectIssues(
+  issues: PolicyValidationIssue[],
+  allowedReasonCodes: ReadonlySet<PolicyValidationReasonCode>
+): PolicyValidationIssue[] {
+  return issues.filter(
+    (issue) =>
+      GLOBAL_POLICY_REASON_CODES.has(issue.reason_code) || allowedReasonCodes.has(issue.reason_code)
+  );
+}
+
+function collectIssueReasonCodes(
+  issues: PolicyValidationIssue[]
+): PolicyEnforcementReasonCode[] {
+  return [...new Set(issues.map((issue) => issue.reason_code))];
+}
+
+function describeCoveragePolicy(policy: unknown): string {
+  const candidate = policy as {
+    coverage?: {
+      scope?: unknown;
+      enforcement?: unknown;
+    };
+  };
+
+  return `${String(candidate.coverage?.scope)}/${String(candidate.coverage?.enforcement)}`;
+}
+
+function describeParallelismPolicy(policy: unknown): string {
+  const candidate = policy as {
+    parallelism?: {
+      max_concurrent_tasks?: unknown;
+      serialize_on_uncertainty?: unknown;
+    };
+  };
+
+  return `max=${String(candidate.parallelism?.max_concurrent_tasks)}, serialize_on_uncertainty=${String(candidate.parallelism?.serialize_on_uncertainty)}`;
+}

--- a/tests/core/policy-enforcement.test.ts
+++ b/tests/core/policy-enforcement.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { createDefaultPolicyConfig } from "../../src/core/contracts/policy.js";
+import {
+  evaluateBootstrapPolicyChecks,
+  evaluatePolicyConfigCheck
+} from "../../src/core/policy/enforcement.js";
+
+describe("policy enforcement", () => {
+  it("emits a deterministic policy_config failure with aggregated reason codes", () => {
+    const result = evaluatePolicyConfigCheck({
+      coverage: {
+        scope: "full-repo",
+        enforcement: "warn-only"
+      },
+      parallelism: {
+        max_concurrent_tasks: 0,
+        serialize_on_uncertainty: "yes"
+      },
+      gates: {
+        enabled_by_default: {
+          proposal_approval: true,
+          spec_approval: "sometimes",
+          execution_start: false
+        }
+      }
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: "policy_config",
+        status: "fail",
+        reason_codes: expect.arrayContaining([
+          "invalid_coverage_scope",
+          "invalid_coverage_enforcement",
+          "invalid_parallelism_max_concurrent_tasks",
+          "invalid_parallelism_serialize_on_uncertainty",
+          "invalid_enabled_gate_type",
+          "missing_enabled_gate_key",
+          "missing_applicable_project_modes"
+        ])
+      })
+    );
+  });
+
+  it("evaluates bootstrap coverage, parallelism, and gate checks through one module", () => {
+    const invalidPolicy = createDefaultPolicyConfig();
+    invalidPolicy.coverage.enforcement = "unexpected" as never;
+
+    const checks = evaluateBootstrapPolicyChecks(invalidPolicy);
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        id: "coverage_policy",
+        status: "fail",
+        reason_codes: ["invalid_coverage_enforcement"]
+      }),
+      expect.objectContaining({
+        id: "parallelism_policy",
+        status: "pass",
+        reason_codes: ["parallelism_supported"]
+      }),
+      expect.objectContaining({
+        id: "gate_policy",
+        status: "pass",
+        reason_codes: ["gate_policy_supported"]
+      })
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared policy enforcement module with deterministic outputs and reason codes
- route doctor, explain, and CI policy checks through the shared boundary
- add focused tests for policy enforcement aggregation and bootstrap policy evaluation

Closes #44