### PR TITLE
feat: add replayable run diagnostics

### DIFF
--- a/src/core/diagnostics/replayableRun.ts
+++ b/src/core/diagnostics/replayableRun.ts
@@ -446,12 +446,15 @@ function normalizeReplayableRunRecord(value: unknown): ReplayableRunRecord {
   return {
     schema_version: "v1",
     run_id: normalizeNonEmptyString(value.run_id, "run_id", "invalid_record"),
-    replayable: typeof value.replayable === "boolean" ? value.replayable : false,
+    replayable: normalizeBoolean(value.replayable, "replayable", "invalid_record"),
     missing_source_refs: Array.isArray(value.missing_source_refs)
-      ? value.missing_source_refs.map((sourceRef, index) =>
-          normalizeSourceRef(sourceRef, "record.missing_source_refs", index, "invalid_record")
-        )
-      : [],
+      ? normalizeSourceRefs(value.missing_source_refs, "record.missing_source_refs", "invalid_record")
+      : (() => {
+          throw new ReplayableRunError(
+            "invalid_record",
+            "replayable run record missing_source_refs must be an array."
+          );
+        })(),
     artifacts: Array.isArray(value.artifacts)
       ? value.artifacts.map((artifact, index) =>
           normalizeRecordArtifactEntry(artifact, index)
@@ -533,9 +536,7 @@ function normalizeReplayStepSourceRefs(value: unknown): ArtifactSourceRef[] {
     );
   }
 
-  return value.map((sourceRef, sourceRefIndex) =>
-    normalizeSourceRef(sourceRef, "record.replay_order", sourceRefIndex, "invalid_record")
-  );
+  return normalizeSourceRefs(value, "record.replay_order", "invalid_record");
 }
 
 function normalizeContractArtifactIds(contractArtifactIds: string[]): Set<string> {
@@ -563,6 +564,18 @@ function normalizeNonEmptyString(
   }
 
   return value.trim();
+}
+
+function normalizeBoolean(
+  value: unknown,
+  fieldName: string,
+  code: ReplayableRunErrorCode
+): boolean {
+  if (typeof value !== "boolean") {
+    throw new ReplayableRunError(code, `${fieldName} must be a boolean.`);
+  }
+
+  return value;
 }
 
 function normalizeArtifactVersion(
@@ -616,9 +629,12 @@ function compareContractDriftIssues(left: ContractDriftIssue, right: ContractDri
     return byConsumerId;
   }
 
-  const byConsumerVersion = left.consumer_artifact_version.localeCompare(right.consumer_artifact_version);
+  const byConsumerVersion = compareArtifactVersions(
+    left.consumer_artifact_version,
+    right.consumer_artifact_version
+  );
   if (byConsumerVersion !== 0) {
-    return compareArtifactVersions(left.consumer_artifact_version, right.consumer_artifact_version);
+    return byConsumerVersion;
   }
 
   const byContractId = left.contract_artifact_id.localeCompare(right.contract_artifact_id);

--- a/tests/diagnostics/replayable-run.test.ts
+++ b/tests/diagnostics/replayable-run.test.ts
@@ -255,6 +255,50 @@ describe("replayable run diagnostics", () => {
       })
     );
   });
+
+  it("fails with invalid_record when replayable has the wrong type", () => {
+    expect(() =>
+      diagnoseContractDrift({
+        record: {
+          schema_version: "v1",
+          run_id: "run-007",
+          replayable: "yes",
+          missing_source_refs: [],
+          artifacts: [],
+          replay_order: []
+        },
+        artifact_index: createArtifactIndex(),
+        contract_artifact_ids: ["spec.main"]
+      })
+    ).toThrowError(
+      expect.objectContaining<Partial<ReplayableRunError>>({
+        code: "invalid_record",
+        message: "replayable must be a boolean."
+      })
+    );
+  });
+
+  it("fails with invalid_record when missing_source_refs has the wrong type", () => {
+    expect(() =>
+      diagnoseContractDrift({
+        record: {
+          schema_version: "v1",
+          run_id: "run-008",
+          replayable: true,
+          missing_source_refs: "not-an-array",
+          artifacts: [],
+          replay_order: []
+        },
+        artifact_index: createArtifactIndex(),
+        contract_artifact_ids: ["spec.main"]
+      })
+    ).toThrowError(
+      expect.objectContaining<Partial<ReplayableRunError>>({
+        code: "invalid_record",
+        message: "replayable run record missing_source_refs must be an array."
+      })
+    );
+  });
 });
 
 function createArtifact(input: {


### PR DESCRIPTION
## Summary
- add replayable run recording from artifact metadata with deterministic replay ordering
- add contract drift diagnostics against the current artifact index
- add regression coverage for replayability, missing source refs, and stale contract detection

Closes #52