### PR TITLE
docs: backfill core invariant comments

### DIFF
--- a/src/core/artifacts/index.ts
+++ b/src/core/artifacts/index.ts
@@ -38,6 +38,10 @@ export class ArtifactIndexError extends Error {
   }
 }
 
+/**
+ * Create an empty artifact-version index. The on-disk file is optional, so the
+ * empty index is the bootstrap state for new repositories and missing files.
+ */
 export function createArtifactIndex(): ArtifactIndex {
   return {
     schema_version: "v1",
@@ -45,6 +49,10 @@ export function createArtifactIndex(): ArtifactIndex {
   };
 }
 
+/**
+ * Register one artifact version in canonical order. Re-registering the same
+ * version is a no-op so writers can safely call this after idempotent publishes.
+ */
 export function registerArtifactVersion(
   index: ArtifactIndex,
   input: RegisterArtifactVersionInput
@@ -70,6 +78,10 @@ export function registerArtifactVersion(
   return buildIndexFromMap(byArtifact);
 }
 
+/**
+ * Resolve either the latest known version for an artifact or confirm that a
+ * requested version still exists in the index.
+ */
 export function resolveArtifactVersion(
   index: ArtifactIndex,
   input: ResolveArtifactVersionInput
@@ -88,6 +100,10 @@ export function resolveArtifactVersion(
   return entry.versions.includes(input.requested_version) ? input.requested_version : undefined;
 }
 
+/**
+ * Materialize the latest-version lookup used by validation and drift checks so
+ * callers do not have to traverse index entries repeatedly.
+ */
 export function buildArtifactVersionIndex(index: ArtifactIndex): Record<string, ArtifactVersion> {
   const normalized = normalizeArtifactIndex(index);
   const lookup: Record<string, ArtifactVersion> = {};
@@ -99,6 +115,10 @@ export function buildArtifactVersionIndex(index: ArtifactIndex): Record<string, 
   return lookup;
 }
 
+/**
+ * Read and validate the persisted artifact index. A missing file is treated as
+ * an empty index so new repositories do not need an eager bootstrap write.
+ */
 export async function readArtifactIndex(filePath: string): Promise<ArtifactIndex> {
   try {
     const raw = await readFile(filePath, "utf8");
@@ -124,6 +144,10 @@ export async function readArtifactIndex(filePath: string): Promise<ArtifactIndex
   }
 }
 
+/**
+ * Persist a normalized index to disk. The write path always revalidates first
+ * so callers cannot accidentally serialize a partially-invalid in-memory shape.
+ */
 export async function writeArtifactIndex(
   filePath: string,
   index: ArtifactIndex
@@ -184,6 +208,8 @@ function normalizeArtifactIndex(index: unknown): ArtifactIndex {
 
     const latest = ensureArtifactVersion(rawEntry.latest_version);
     const expectedLatest = canonicalVersions[canonicalVersions.length - 1];
+    // latest_version is stored redundantly for quick lookup, so we validate it
+    // against the canonical version list instead of trusting the serialized copy.
     if (latest !== expectedLatest) {
       throw new ArtifactIndexError(
         "invalid_index",

--- a/src/core/artifacts/versioning.ts
+++ b/src/core/artifacts/versioning.ts
@@ -22,10 +22,18 @@ interface CreateNextArtifactMetadataInput {
   createdTimestamp?: Date;
 }
 
+/**
+ * Hash published artifact content so metadata can prove exactly which bytes a
+ * given version was derived from.
+ */
 export function hashArtifactContent(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
+/**
+ * Derive the next semantic artifact version in the simple v<number> lineage
+ * used throughout SpecForge.
+ */
 export function deriveArtifactVersion(previousVersion?: ArtifactVersion): ArtifactVersion {
   if (!previousVersion) {
     return "v1";
@@ -40,6 +48,10 @@ export function deriveArtifactVersion(previousVersion?: ArtifactVersion): Artifa
   return `v${next}`;
 }
 
+/**
+ * Create metadata for the first published version of an artifact. Initial
+ * versions intentionally have no parent_version pointer.
+ */
 export function createInitialArtifactMetadata(
   input: CreateInitialArtifactMetadataInput
 ): ArtifactMetadata {
@@ -53,6 +65,10 @@ export function createInitialArtifactMetadata(
   };
 }
 
+/**
+ * Create metadata for a derived artifact version while preserving explicit
+ * lineage back to the immediately previous published version.
+ */
 export function createNextArtifactMetadata(
   input: CreateNextArtifactMetadataInput
 ): ArtifactMetadata {

--- a/src/core/contracts/policy.ts
+++ b/src/core/contracts/policy.ts
@@ -54,6 +54,10 @@ export interface PolicyValidationResult {
   issues: PolicyValidationIssue[];
 }
 
+/**
+ * Render a short, deterministic issue summary for CLI surfaces. The formatter
+ * truncates after a few issues so diagnostics stay readable on one screen.
+ */
 export function formatPolicyValidationIssues(issues: PolicyValidationIssue[]): string {
   const maxIssuesToShow = 3;
   const displayedIssues = issues
@@ -83,6 +87,10 @@ const DEFAULT_APPLICABLE_MODES: Partial<Record<ArtifactGate, ProjectMode[]>> = {
   merge_approval: ["greenfield", "existing-repo", "contribution", "feature-proposal"]
 };
 
+/**
+ * Return the conservative bootstrap policy SpecForge assumes when no explicit
+ * repo policy file overrides it.
+ */
 export function createDefaultPolicyConfig(): SpecForgePolicyConfig {
   return {
     coverage: {
@@ -104,6 +112,11 @@ export function isKnownGate(gate: string): gate is ArtifactGate {
   return ARTIFACT_GATES.includes(gate as ArtifactGate);
 }
 
+/**
+ * Validate one policy object against the current v1 contract. The validator is
+ * intentionally explicit instead of schema-library driven so reason codes and
+ * messages stay stable across CLI, CI, and tests.
+ */
 export function validatePolicyConfig(candidate: unknown): PolicyValidationResult {
   const issues: PolicyValidationIssue[] = [];
   if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
@@ -218,6 +231,8 @@ function validateEnabledGates(
   }
 
   const enabledByDefault = candidate as Record<string, unknown>;
+  // Report unknown keys first so typos are visible even when required known
+  // gate keys are also missing from the same object.
   for (const gate of Object.keys(enabledByDefault)) {
     if (!isKnownGate(gate)) {
       issues.push({

--- a/src/core/spec/ownership.ts
+++ b/src/core/spec/ownership.ts
@@ -22,6 +22,9 @@ export interface ArtifactOwnershipContract {
   owner_operation: string;
 }
 
+// Each artifact kind has one canonical owning operation. Validation and
+// maintenance code relies on this registry instead of inferring broader write
+// permissions from file paths or command names.
 export const ARTIFACT_OWNERSHIP_REGISTRY: Record<ArtifactKind, ArtifactOwnershipContract> = {
   idea_brief: {
     artifact_kind: "idea_brief",
@@ -81,6 +84,11 @@ export const ARTIFACT_OWNERSHIP_REGISTRY: Record<ArtifactKind, ArtifactOwnership
   }
 };
 
+/**
+ * Infer the owned artifact kind from the published artifact_id naming scheme.
+ * The mapping is intentionally conservative: unknown ids stay unknown instead
+ * of being coerced into a nearby kind.
+ */
 export function inferArtifactKindFromId(artifactId: string): ArtifactKind | undefined {
   if (artifactId === "idea_brief") {
     return "idea_brief";
@@ -141,6 +149,10 @@ export function inferArtifactKindFromId(artifactId: string): ArtifactKind | unde
   return undefined;
 }
 
+/**
+ * Guard helper for validation paths that receive artifact-kind strings from
+ * serialized artifacts or inferred ids.
+ */
 export function isOwnedArtifactKind(kind: string): kind is ArtifactKind {
   return ARTIFACT_KINDS.includes(kind as ArtifactKind);
 }

--- a/src/core/spec/validation.ts
+++ b/src/core/spec/validation.ts
@@ -20,6 +20,11 @@ interface ValidateArtifactReferencesInput {
   artifactVersionIndex: ArtifactVersionIndex;
 }
 
+/**
+ * Validate that required PRD/SPEC sections are still populated after generation
+ * or mutation. The result is additive so callers can merge these issues with
+ * other structural validation findings.
+ */
 export function validateRequiredSections(artifact: SectionedArtifact): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
@@ -52,6 +57,11 @@ export function validateRequiredSections(artifact: SectionedArtifact): Validatio
   return issues;
 }
 
+/**
+ * Validate artifact source refs against the current artifact-version index.
+ * This is intentionally latest-version aware so stale references show up as
+ * version drift instead of silently passing because the id still exists.
+ */
 export function validateArtifactReferences(
   input: ValidateArtifactReferencesInput
 ): ValidationIssue[] {
@@ -70,6 +80,8 @@ export function validateArtifactReferences(
     }
 
     const indexedVersion = input.artifactVersionIndex[reference.artifact_id];
+    // A missing indexed version means the referenced artifact either was never
+    // published into the known set or has fallen out of the current baseline.
     if (!indexedVersion) {
       issues.push({
         code: "invalid_reference",


### PR DESCRIPTION
## Summary
- backfill high-signal comments across older artifact, ownership, validation, and policy primitives
- document invariants and intentionally conservative defaults without adding line-by-line narration
- keep behavior unchanged while improving onboarding for contributors

Closes #70