### PR TITLE
feat: add repository risk hotspot analysis

### DIFF
--- a/src/core/diagnostics/inspect.ts
+++ b/src/core/diagnostics/inspect.ts
@@ -1,6 +1,11 @@
 import { join } from "node:path";
 
 import { mergeDryRunReports, type DryRunReport } from "../contracts/dryRun.js";
+import {
+  RiskAnalysisError,
+  analyzeRepositoryRisk,
+  type RepositoryRiskAnalysis
+} from "./riskAnalysis.js";
 import type { ArchitectureSummaryArtifact } from "../operations/mapArchitectureFromRepo.js";
 import {
   MapArchitectureFromRepoError,
@@ -26,7 +31,11 @@ const STANDARD_MAX_FILES = 200;
 const DEEP_MAX_FILES = 1000;
 
 export type InspectScanMode = "standard" | "deep";
-export type InspectErrorCode = "profile_failed" | "architecture_failed" | "architecture_docs_failed";
+export type InspectErrorCode =
+  | "profile_failed"
+  | "architecture_failed"
+  | "risk_analysis_failed"
+  | "architecture_docs_failed";
 
 export class InspectError extends Error {
   readonly code: InspectErrorCode;
@@ -49,6 +58,7 @@ export interface InspectResult {
   architecture_docs_path?: string;
   repo_profile: RepoProfileArtifact;
   architecture_summary: ArchitectureSummaryArtifact;
+  risk_analysis: RepositoryRiskAnalysis;
   dry_run?: DryRunReport;
 }
 
@@ -133,6 +143,24 @@ export async function runInspect(input: RunInspectInput = {}): Promise<InspectRe
     throw error;
   }
 
+  let riskAnalysis: RepositoryRiskAnalysis;
+  try {
+    riskAnalysis = analyzeRepositoryRisk({
+      repo_profile: repoProfile,
+      architecture_summary: architectureSummary
+    });
+  } catch (error) {
+    if (error instanceof RiskAnalysisError) {
+      throw new InspectError(
+        "risk_analysis_failed",
+        `Risk analysis failed: ${error.message}`,
+        error
+      );
+    }
+
+    throw error;
+  }
+
   let architectureSummaryMarkdownPath: string | undefined;
   let architectureDocsPath: string | undefined;
   if (input.write_architecture_docs) {
@@ -173,6 +201,7 @@ export async function runInspect(input: RunInspectInput = {}): Promise<InspectRe
     ...(architectureDocsPath ? { architecture_docs_path: architectureDocsPath } : {}),
     repo_profile: repoProfile,
     architecture_summary: architectureSummary,
+    risk_analysis: riskAnalysis,
     ...(dryRun ? { dry_run: dryRun } : {})
   };
 }
@@ -220,6 +249,19 @@ export function formatInspectReport(result: InspectResult): string {
     lines.push(
       `- ${subsystem.id} (${subsystem.file_count} files, ${subsystem.uncertainty} uncertainty)`
     );
+  }
+
+  lines.push("", "Risk Hotspots");
+  if (result.risk_analysis.hotspots.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const hotspot of result.risk_analysis.hotspots) {
+      lines.push(`- ${hotspot.subsystem_id} (${hotspot.level} risk, score ${hotspot.score})`);
+      for (const providerScore of hotspot.provider_scores) {
+        lines.push(`  - ${providerScore.provider_id}: ${providerScore.score}`);
+        lines.push(`    ${providerScore.rationale}`);
+      }
+    }
   }
 
   return `${lines.join("\n")}\n`;

--- a/src/core/diagnostics/riskAnalysis.ts
+++ b/src/core/diagnostics/riskAnalysis.ts
@@ -1,0 +1,281 @@
+import type { ArchitectureSummaryArtifact, ArchitectureSubsystem } from "../operations/mapArchitectureFromRepo.js";
+import type { RepoProfileArtifact } from "../operations/profileRepository.js";
+
+export type RiskAnalysisErrorCode = "invalid_input";
+export type RiskProviderId = "complexity" | "coverage" | "architecture_risk";
+export type RiskLevel = "low" | "medium" | "high";
+
+export class RiskAnalysisError extends Error {
+  readonly code: RiskAnalysisErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: RiskAnalysisErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "RiskAnalysisError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface RiskProviderDefinition {
+  provider_id: RiskProviderId;
+  label: string;
+  description: string;
+}
+
+export interface RiskProviderScore {
+  provider_id: RiskProviderId;
+  score: number;
+  rationale: string;
+  evidence_refs: string[];
+}
+
+export interface RiskHotspot {
+  subsystem_id: string;
+  label: string;
+  score: number;
+  level: RiskLevel;
+  evidence_refs: string[];
+  provider_scores: RiskProviderScore[];
+}
+
+export interface RepositoryRiskAnalysis {
+  providers: RiskProviderDefinition[];
+  hotspots: RiskHotspot[];
+}
+
+export interface AnalyzeRepositoryRiskInput {
+  repo_profile?: RepoProfileArtifact;
+  architecture_summary?: ArchitectureSummaryArtifact;
+}
+
+const PROVIDERS: RiskProviderDefinition[] = [
+  {
+    provider_id: "complexity",
+    label: "Complexity",
+    description: "Scores subsystem size from bounded file-count evidence."
+  },
+  {
+    provider_id: "coverage",
+    label: "Coverage",
+    description: "Scores likely test coverage gaps from sampled repository evidence."
+  },
+  {
+    provider_id: "architecture_risk",
+    label: "Architecture Risk",
+    description: "Scores architectural uncertainty from bounded subsystem inference confidence."
+  }
+];
+
+/**
+ * Score bounded repository evidence into deterministic hotspots. The heuristic
+ * intentionally stays simple: subsystem size, likely test coverage, and
+ * architecture uncertainty are weighted into one sortable score.
+ */
+export function analyzeRepositoryRisk(input: AnalyzeRepositoryRiskInput): RepositoryRiskAnalysis {
+  const repoProfile = ensureRepoProfile(input.repo_profile);
+  const architectureSummary = ensureArchitectureSummary(input.architecture_summary);
+
+  if (repoProfile.repository_root !== architectureSummary.repository_root) {
+    throw new RiskAnalysisError(
+      "invalid_input",
+      "repo_profile and architecture_summary must share the same repository_root."
+    );
+  }
+
+  const sampledFiles = [...repoProfile.evidence.sampled_files];
+  const hotspots = architectureSummary.subsystems
+    .filter((subsystem) => !isTestOnlySubsystem(subsystem))
+    .map((subsystem) => buildHotspot(subsystem, sampledFiles))
+    .sort(compareHotspots);
+
+  return {
+    providers: PROVIDERS.map((provider) => ({ ...provider })),
+    hotspots
+  };
+}
+
+function ensureRepoProfile(repoProfile?: RepoProfileArtifact): RepoProfileArtifact {
+  if (!repoProfile || repoProfile.kind !== "repo_profile") {
+    throw new RiskAnalysisError("invalid_input", "repo_profile must be a repo_profile artifact.");
+  }
+
+  return repoProfile;
+}
+
+function ensureArchitectureSummary(
+  architectureSummary?: ArchitectureSummaryArtifact
+): ArchitectureSummaryArtifact {
+  if (!architectureSummary || architectureSummary.kind !== "architecture_summary") {
+    throw new RiskAnalysisError(
+      "invalid_input",
+      "architecture_summary must be an architecture_summary artifact."
+    );
+  }
+
+  return architectureSummary;
+}
+
+function isTestOnlySubsystem(subsystem: ArchitectureSubsystem): boolean {
+  return subsystem.id.startsWith("tests/") || subsystem.inferred_responsibility === "Test coverage";
+}
+
+function buildHotspot(subsystem: ArchitectureSubsystem, sampledFiles: string[]): RiskHotspot {
+  const matchingTests = findMatchingTestEvidence(subsystem, sampledFiles);
+  const providerScores: [RiskProviderScore, RiskProviderScore, RiskProviderScore] = [
+    buildComplexityScore(subsystem),
+    buildCoverageScore(subsystem, matchingTests),
+    buildArchitectureRiskScore(subsystem)
+  ];
+  const [complexityScore, coverageScore, architectureRiskScore] = providerScores;
+  const evidenceRefs = sortUniqueStrings(
+    providerScores.flatMap((providerScore) => providerScore.evidence_refs)
+  );
+  const score = Math.round(
+    complexityScore.score * 0.4 + coverageScore.score * 0.4 + architectureRiskScore.score * 0.2
+  );
+
+  return {
+    subsystem_id: subsystem.id,
+    label: subsystem.label,
+    score,
+    level: toRiskLevel(score),
+    evidence_refs: evidenceRefs,
+    provider_scores: providerScores
+  };
+}
+
+function buildComplexityScore(subsystem: ArchitectureSubsystem): RiskProviderScore {
+  const score =
+    subsystem.file_count >= 6 ? 80 :
+    subsystem.file_count >= 4 ? 60 :
+    subsystem.file_count >= 2 ? 40 :
+    20;
+
+  let descriptor = "small";
+  if (score === 40) {
+    descriptor = "moderate";
+  } else if (score === 60) {
+    descriptor = "large";
+  } else if (score === 80) {
+    descriptor = "very large";
+  }
+
+  return {
+    provider_id: "complexity",
+    score,
+    rationale: `${subsystem.file_count} sampled files indicate ${descriptor} subsystem size.`,
+    evidence_refs: [...subsystem.evidence_refs]
+  };
+}
+
+function buildCoverageScore(
+  subsystem: ArchitectureSubsystem,
+  matchingTests: string[]
+): RiskProviderScore {
+  if (matchingTests.length === 0) {
+    return {
+      provider_id: "coverage",
+      score: 85,
+      rationale: "No matching test evidence was found for this subsystem.",
+      evidence_refs: []
+    };
+  }
+
+  if (matchingTests.length >= Math.max(2, Math.ceil(subsystem.file_count / 2))) {
+    return {
+      provider_id: "coverage",
+      score: 15,
+      rationale: "Matching test evidence covers this subsystem with bounded confidence.",
+      evidence_refs: [...matchingTests]
+    };
+  }
+
+  return {
+    provider_id: "coverage",
+    score: 40,
+    rationale: "Limited matching test evidence was found for this subsystem.",
+    evidence_refs: [...matchingTests]
+  };
+}
+
+function buildArchitectureRiskScore(subsystem: ArchitectureSubsystem): RiskProviderScore {
+  if (subsystem.uncertainty === "medium") {
+    return {
+      provider_id: "architecture_risk",
+      score: 55,
+      rationale: "Subsystem inference still carries medium architectural uncertainty.",
+      evidence_refs: [...subsystem.evidence_refs]
+    };
+  }
+
+  return {
+    provider_id: "architecture_risk",
+    score: 15,
+    rationale: "Subsystem inference is backed by multiple evidence refs with low uncertainty.",
+    evidence_refs: [...subsystem.evidence_refs]
+  };
+}
+
+function findMatchingTestEvidence(subsystem: ArchitectureSubsystem, sampledFiles: string[]): string[] {
+  const leafSegment = subsystem.id.split("/").filter((segment) => segment.length > 0).pop();
+  const sourceBaseNames = new Set(subsystem.evidence_refs.map((path) => normalizePathBaseName(path)));
+
+  return sortUniqueStrings(
+    sampledFiles.filter((path) => {
+      if (!isTestPath(path)) {
+        return false;
+      }
+
+      const pathSegments = path.split("/").filter((segment) => segment.length > 0);
+      if (leafSegment && pathSegments.includes(leafSegment)) {
+        return true;
+      }
+
+      return sourceBaseNames.has(normalizePathBaseName(path));
+    })
+  );
+}
+
+function isTestPath(path: string): boolean {
+  return (
+    path.includes("/tests/") ||
+    path.startsWith("tests/") ||
+    path.includes("__tests__") ||
+    /\.test\.[^/]+$/i.test(path) ||
+    /\.spec\.[^/]+$/i.test(path)
+  );
+}
+
+function normalizePathBaseName(path: string): string {
+  const fileName = path.split("/").pop() ?? path;
+  return fileName
+    .replace(/\.[^.]+$/u, "")
+    .replace(/(?:\.test|\.spec)$/u, "")
+    .trim()
+    .toLowerCase();
+}
+
+function toRiskLevel(score: number): RiskLevel {
+  if (score >= 70) {
+    return "high";
+  }
+
+  if (score >= 40) {
+    return "medium";
+  }
+
+  return "low";
+}
+
+function compareHotspots(left: RiskHotspot, right: RiskHotspot): number {
+  if (right.score !== left.score) {
+    return right.score - left.score;
+  }
+
+  return left.subsystem_id.localeCompare(right.subsystem_id);
+}
+
+function sortUniqueStrings(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}

--- a/tests/cli/inspect-command.test.ts
+++ b/tests/cli/inspect-command.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it } from "vitest";
 import { runCli } from "../../src/cli.js";
 import type { InspectResult } from "../../src/core/diagnostics/inspect.js";
 import type { DryRunReport } from "../../src/core/contracts/dryRun.js";
+import type { RepositoryRiskAnalysis } from "../../src/core/diagnostics/riskAnalysis.js";
+
+const EMPTY_RISK_ANALYSIS: RepositoryRiskAnalysis = {
+  providers: [],
+  hotspots: []
+};
 
 function buildInspectResult(overrides: Partial<InspectResult> = {}): InspectResult {
   return {
@@ -60,6 +66,7 @@ function buildInspectResult(overrides: Partial<InspectResult> = {}): InspectResu
       ],
       summary_markdown: "# Architecture Summary"
     },
+    risk_analysis: EMPTY_RISK_ANALYSIS,
     ...overrides
   };
 }

--- a/tests/diagnostics/inspect.test.ts
+++ b/tests/diagnostics/inspect.test.ts
@@ -48,7 +48,9 @@ describe("runInspect success paths", () => {
       { path: "tsconfig.json", content: "{\"compilerOptions\":{}}" },
       { path: "src/api/routes.ts", content: "export const routes = [];" },
       { path: "src/api/service.ts", content: "export const service = {};" },
+      { path: "src/cli/format.ts", content: "export const format = () => {};" },
       { path: "src/cli/main.ts", content: "export const main = () => {};" },
+      { path: "tests/api/routes.test.ts", content: "export const routeTests = [];" },
       { path: "README.md", content: "# Demo\n" }
     ]);
 
@@ -70,7 +72,12 @@ describe("runInspect success paths", () => {
     );
     expect(result.architecture_summary.subsystems.map((subsystem) => subsystem.id)).toEqual([
       "src/api",
-      "src/cli"
+      "src/cli",
+      "tests/api"
+    ]);
+    expect(result.risk_analysis.hotspots.map((hotspot) => hotspot.subsystem_id)).toEqual([
+      "src/cli",
+      "src/api"
     ]);
 
     expect(await readFile(join(repoRoot, "README.md"), "utf8")).toBe(originalReadme);
@@ -79,6 +86,7 @@ describe("runInspect success paths", () => {
       "package.json",
       "README.md",
       "src",
+      "tests",
       "tsconfig.json"
     ]);
 
@@ -86,7 +94,9 @@ describe("runInspect success paths", () => {
     expect(report).toContain("SpecForge Inspect");
     expect(report).toContain("repo_profile@v1");
     expect(report).toContain("architecture_summary@v1");
-    expect(report).toContain("src/api");
+    expect(report).toContain("Risk Hotspots");
+    expect(report).toContain("src/cli (medium risk, score 53)");
+    expect(report).toContain("coverage: 85");
   });
 
   it("supports bounded deep inspection by increasing the scan budget", async () => {

--- a/tests/diagnostics/risk-analysis.test.ts
+++ b/tests/diagnostics/risk-analysis.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+
+import { analyzeRepositoryRisk } from "../../src/core/diagnostics/riskAnalysis.js";
+import type { ArchitectureSummaryArtifact } from "../../src/core/operations/mapArchitectureFromRepo.js";
+import type { RepoProfileArtifact } from "../../src/core/operations/profileRepository.js";
+
+describe("repository risk analysis", () => {
+  it("produces deterministic hotspot scores from complexity, coverage, and uncertainty providers", () => {
+    const repoProfile = createRepoProfile({
+      sampled_files: [
+        "src/api/routes.ts",
+        "src/api/service.ts",
+        "src/api/controller.ts",
+        "src/cli/main.ts",
+        "src/cli/format.ts",
+        "tests/api/routes.test.ts"
+      ]
+    });
+    const architectureSummary = createArchitectureSummary({
+      subsystems: [
+        {
+          id: "src/api",
+          label: "src/api",
+          inferred_responsibility: "API/backend surface",
+          file_count: 3,
+          evidence_refs: [
+            "src/api/controller.ts",
+            "src/api/routes.ts",
+            "src/api/service.ts"
+          ],
+          uncertainty: "low"
+        },
+        {
+          id: "src/cli",
+          label: "src/cli",
+          inferred_responsibility: "CLI entrypoints",
+          file_count: 2,
+          evidence_refs: ["src/cli/format.ts", "src/cli/main.ts"],
+          uncertainty: "medium"
+        },
+        {
+          id: "tests/api",
+          label: "tests/api",
+          inferred_responsibility: "Test coverage",
+          file_count: 1,
+          evidence_refs: ["tests/api/routes.test.ts"],
+          uncertainty: "low"
+        }
+      ]
+    });
+
+    const result = analyzeRepositoryRisk({
+      repo_profile: repoProfile,
+      architecture_summary: architectureSummary
+    });
+
+    expect(result.providers).toEqual([
+      {
+        provider_id: "complexity",
+        label: "Complexity",
+        description: "Scores subsystem size from bounded file-count evidence."
+      },
+      {
+        provider_id: "coverage",
+        label: "Coverage",
+        description: "Scores likely test coverage gaps from sampled repository evidence."
+      },
+      {
+        provider_id: "architecture_risk",
+        label: "Architecture Risk",
+        description: "Scores architectural uncertainty from bounded subsystem inference confidence."
+      }
+    ]);
+
+    expect(result.hotspots).toEqual([
+      {
+        subsystem_id: "src/cli",
+        label: "src/cli",
+        score: 61,
+        level: "medium",
+        evidence_refs: ["src/cli/format.ts", "src/cli/main.ts"],
+        provider_scores: [
+          {
+            provider_id: "complexity",
+            score: 40,
+            rationale: "2 sampled files indicate moderate subsystem size.",
+            evidence_refs: ["src/cli/format.ts", "src/cli/main.ts"]
+          },
+          {
+            provider_id: "coverage",
+            score: 85,
+            rationale: "No matching test evidence was found for this subsystem.",
+            evidence_refs: []
+          },
+          {
+            provider_id: "architecture_risk",
+            score: 55,
+            rationale: "Subsystem inference still carries medium architectural uncertainty.",
+            evidence_refs: ["src/cli/format.ts", "src/cli/main.ts"]
+          }
+        ]
+      },
+      {
+        subsystem_id: "src/api",
+        label: "src/api",
+        score: 35,
+        level: "low",
+        evidence_refs: [
+          "src/api/controller.ts",
+          "src/api/routes.ts",
+          "src/api/service.ts",
+          "tests/api/routes.test.ts"
+        ],
+        provider_scores: [
+          {
+            provider_id: "complexity",
+            score: 40,
+            rationale: "3 sampled files indicate moderate subsystem size.",
+            evidence_refs: [
+              "src/api/controller.ts",
+              "src/api/routes.ts",
+              "src/api/service.ts"
+            ]
+          },
+          {
+            provider_id: "coverage",
+            score: 40,
+            rationale: "Limited matching test evidence was found for this subsystem.",
+            evidence_refs: ["tests/api/routes.test.ts"]
+          },
+          {
+            provider_id: "architecture_risk",
+            score: 15,
+            rationale: "Subsystem inference is backed by multiple evidence refs with low uncertainty.",
+            evidence_refs: [
+              "src/api/controller.ts",
+              "src/api/routes.ts",
+              "src/api/service.ts"
+            ]
+          }
+        ]
+      }
+    ]);
+  });
+});
+
+function createRepoProfile(input: { sampled_files: string[] }): RepoProfileArtifact {
+  return {
+    kind: "repo_profile",
+    metadata: {
+      artifact_id: "repo_profile",
+      artifact_version: "v1",
+      created_timestamp: "2026-03-16T00:00:00.000Z",
+      generator: "operation.profileRepository",
+      source_refs: [],
+      checksum: "0".repeat(64)
+    },
+    project_mode: "existing-repo",
+    repository_root: "/workspace/specforge",
+    scan: {
+      max_files: 200,
+      scanned_file_count: input.sampled_files.length,
+      truncated: false,
+      ignored_directories: [".git", ".specforge"]
+    },
+    evidence: {
+      top_level_entries: ["src", "tests"],
+      sampled_files: input.sampled_files,
+      extension_counts: [
+        { extension: ".test.ts", count: 1 },
+        { extension: ".ts", count: input.sampled_files.length - 1 }
+      ],
+      detected_manifests: ["package.json", "tsconfig.json"],
+      detected_tooling: ["node", "typescript"]
+    }
+  };
+}
+
+function createArchitectureSummary(input: {
+  subsystems: ArchitectureSummaryArtifact["subsystems"];
+}): ArchitectureSummaryArtifact {
+  return {
+    kind: "architecture_summary",
+    metadata: {
+      artifact_id: "architecture_summary",
+      artifact_version: "v1",
+      created_timestamp: "2026-03-16T00:00:00.000Z",
+      generator: "operation.mapArchitectureFromRepo",
+      source_refs: [{ artifact_id: "repo_profile", artifact_version: "v1" }],
+      checksum: "1".repeat(64)
+    },
+    project_mode: "existing-repo",
+    repository_root: "/workspace/specforge",
+    subsystems: input.subsystems,
+    summary_markdown: "# Architecture Summary"
+  };
+}


### PR DESCRIPTION
## Summary
- add deterministic repository risk analysis providers for complexity, coverage, and architecture uncertainty
- surface ordered hotspot scoring in inspect results and the human-readable inspect report
- cover the new scoring and inspect integration with focused tests

Closes #51