### PR TITLE
feat: add architecture diagram generation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,5 +55,6 @@ That generated section is derived from:
 
 The generated snapshot is intended to keep repository-specific subsystem boundaries aligned with:
 - inspect evidence refs
+- generated Mermaid system-context and subsystem-relationship diagrams
 - artifact contracts
 - artifact flow between profiling, architecture mapping, and maintained documentation

--- a/src/core/operations/architectureDiagrams.ts
+++ b/src/core/operations/architectureDiagrams.ts
@@ -1,0 +1,180 @@
+import type { ArchitectureSubsystem, ArchitectureSummaryArtifact } from "./mapArchitectureFromRepo.js";
+import type { RepoProfileArtifact } from "./profileRepository.js";
+
+type RelationshipKind = "likely invokes" | "validates";
+type RelationshipStyle = "solid" | "dashed";
+
+interface ArchitectureRelationship {
+  source_subsystem_id: string;
+  target_subsystem_id: string;
+  kind: RelationshipKind;
+  style: RelationshipStyle;
+  evidence_refs: string[];
+}
+
+/**
+ * Render deterministic Mermaid diagrams from bounded inspect artifacts. The
+ * diagrams stay conservative: they show repository context, clearly justified
+ * subsystem relationships, and the evidence refs behind each inferred edge.
+ */
+export function renderArchitectureDiagramsMarkdown(
+  repoProfile: RepoProfileArtifact,
+  architectureSummary: ArchitectureSummaryArtifact
+): string {
+  const sortedSubsystems = [...architectureSummary.subsystems].sort((left, right) =>
+    left.id.localeCompare(right.id)
+  );
+  const relationships = inferArchitectureRelationships(sortedSubsystems);
+  const lines: string[] = [
+    "## System Context Diagram",
+    "",
+    `Generated from ${repoProfile.metadata.artifact_id}@${repoProfile.metadata.artifact_version} and ${architectureSummary.metadata.artifact_id}@${architectureSummary.metadata.artifact_version}.`,
+    "",
+    "```mermaid",
+    "flowchart LR",
+    '  repository["Repository"]'
+  ];
+
+  for (const subsystem of sortedSubsystems) {
+    lines.push(`  ${toMermaidNodeId(subsystem.id)}["${toMermaidLabel(subsystem)}"]`);
+  }
+  for (const subsystem of sortedSubsystems) {
+    lines.push(`  repository --> ${toMermaidNodeId(subsystem.id)}`);
+  }
+
+  lines.push("```", "", "## Subsystem Relationship Diagram", "", "```mermaid", "flowchart LR");
+
+  for (const subsystem of sortedSubsystems) {
+    lines.push(`  ${toMermaidNodeId(subsystem.id)}["${toMermaidLabel(subsystem)}"]`);
+  }
+  for (const relationship of relationships) {
+    lines.push(renderRelationshipEdge(relationship));
+  }
+
+  lines.push("```", "", "### Relationship Evidence");
+  if (relationships.length === 0) {
+    lines.push("- none inferred from bounded inspect evidence.");
+  } else {
+    for (const relationship of relationships) {
+      const arrow = `${relationship.source_subsystem_id} -> ${relationship.target_subsystem_id}`;
+      lines.push(
+        `- ${arrow} (${relationship.kind}): ${relationship.evidence_refs.join(", ")}`
+      );
+    }
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function inferArchitectureRelationships(
+  subsystems: ArchitectureSubsystem[]
+): ArchitectureRelationship[] {
+  const runtimeSubsystems = subsystems.filter((subsystem) => !isTestCoverageSubsystem(subsystem));
+  const relationships: ArchitectureRelationship[] = [];
+
+  for (const source of runtimeSubsystems) {
+    for (const target of runtimeSubsystems) {
+      if (source.id === target.id) {
+        continue;
+      }
+
+      if (isCliSubsystem(source) && isApiSubsystem(target)) {
+        relationships.push({
+          source_subsystem_id: source.id,
+          target_subsystem_id: target.id,
+          kind: "likely invokes",
+          style: "solid",
+          evidence_refs: sortUniqueStrings([...source.evidence_refs, ...target.evidence_refs])
+        });
+      }
+    }
+  }
+
+  for (const testSubsystem of subsystems.filter(isTestCoverageSubsystem)) {
+    const matchingRuntime = runtimeSubsystems.find(
+      (runtimeSubsystem) => subsystemLeaf(runtimeSubsystem.id) === subsystemLeaf(testSubsystem.id)
+    );
+    if (!matchingRuntime) {
+      continue;
+    }
+
+    relationships.push({
+      source_subsystem_id: testSubsystem.id,
+      target_subsystem_id: matchingRuntime.id,
+      kind: "validates",
+      style: "dashed",
+      evidence_refs: sortUniqueStrings([
+        ...testSubsystem.evidence_refs,
+        ...matchingRuntime.evidence_refs
+      ])
+    });
+  }
+
+  return relationships
+    .sort(compareRelationships)
+    .filter((relationship, index, allRelationships) => {
+      const previous = allRelationships[index - 1];
+      return (
+        !previous ||
+        previous.source_subsystem_id !== relationship.source_subsystem_id ||
+        previous.target_subsystem_id !== relationship.target_subsystem_id ||
+        previous.kind !== relationship.kind
+      );
+    });
+}
+
+function isTestCoverageSubsystem(subsystem: ArchitectureSubsystem): boolean {
+  return subsystem.id.startsWith("tests/") || subsystem.inferred_responsibility === "Test coverage";
+}
+
+function isCliSubsystem(subsystem: ArchitectureSubsystem): boolean {
+  return subsystem.inferred_responsibility === "CLI entrypoints" || subsystem.id.endsWith("/cli");
+}
+
+function isApiSubsystem(subsystem: ArchitectureSubsystem): boolean {
+  return (
+    subsystem.inferred_responsibility === "API/backend surface" || subsystem.id.endsWith("/api")
+  );
+}
+
+function subsystemLeaf(subsystemId: string): string {
+  const segments = subsystemId.split("/").filter((segment) => segment.length > 0);
+  return segments[segments.length - 1] ?? subsystemId;
+}
+
+function compareRelationships(left: ArchitectureRelationship, right: ArchitectureRelationship): number {
+  const sourceComparison = left.source_subsystem_id.localeCompare(right.source_subsystem_id);
+  if (sourceComparison !== 0) {
+    return sourceComparison;
+  }
+
+  const targetComparison = left.target_subsystem_id.localeCompare(right.target_subsystem_id);
+  if (targetComparison !== 0) {
+    return targetComparison;
+  }
+
+  return left.kind.localeCompare(right.kind);
+}
+
+function renderRelationshipEdge(relationship: ArchitectureRelationship): string {
+  const sourceId = toMermaidNodeId(relationship.source_subsystem_id);
+  const targetId = toMermaidNodeId(relationship.target_subsystem_id);
+  if (relationship.style === "dashed") {
+    return `  ${sourceId} -.-> ${targetId}`;
+  }
+
+  return `  ${sourceId} --> ${targetId}`;
+}
+
+function toMermaidNodeId(value: string): string {
+  const normalized = value.replace(/[^A-Za-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  return normalized.length === 0 ? "node" : /^[0-9]/.test(normalized) ? `n_${normalized}` : normalized;
+}
+
+function toMermaidLabel(subsystem: ArchitectureSubsystem): string {
+  return `${subsystem.id}<br/>${subsystem.inferred_responsibility}`.replace(/"/g, "&quot;");
+}
+
+function sortUniqueStrings(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}

--- a/src/core/operations/architectureDiagrams.ts
+++ b/src/core/operations/architectureDiagrams.ts
@@ -179,7 +179,8 @@ function toMermaidNodeId(value: string): string {
   const normalized = value.replace(/[^A-Za-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
   const base =
     normalized.length === 0 ? "node" : /^[0-9]/.test(normalized) ? `n_${normalized}` : normalized;
-  const hashSuffix = stableMermaidIdHash(value).slice(0, 6);
+  const rawHash = stableMermaidIdHash(value);
+  const hashSuffix = rawHash.padStart(6, "0").slice(0, 6);
 
   return `${base}__${hashSuffix}`;
 }

--- a/src/core/operations/architectureDiagrams.ts
+++ b/src/core/operations/architectureDiagrams.ts
@@ -180,7 +180,7 @@ function toMermaidNodeId(value: string): string {
   const base =
     normalized.length === 0 ? "node" : /^[0-9]/.test(normalized) ? `n_${normalized}` : normalized;
   const rawHash = stableMermaidIdHash(value);
-  const hashSuffix = rawHash.padStart(6, "0").slice(0, 6);
+  const hashSuffix = rawHash.padStart(6, "0").slice(-6);
 
   return `${base}__${hashSuffix}`;
 }

--- a/src/core/operations/architectureDiagrams.ts
+++ b/src/core/operations/architectureDiagrams.ts
@@ -166,13 +166,46 @@ function renderRelationshipEdge(relationship: ArchitectureRelationship): string 
   return `  ${sourceId} --> ${targetId}`;
 }
 
+function stableMermaidIdHash(value: string): string {
+  let hash = 5381;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 33) ^ value.charCodeAt(index);
+  }
+
+  return (hash >>> 0).toString(36);
+}
+
 function toMermaidNodeId(value: string): string {
   const normalized = value.replace(/[^A-Za-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
-  return normalized.length === 0 ? "node" : /^[0-9]/.test(normalized) ? `n_${normalized}` : normalized;
+  const base =
+    normalized.length === 0 ? "node" : /^[0-9]/.test(normalized) ? `n_${normalized}` : normalized;
+  const hashSuffix = stableMermaidIdHash(value).slice(0, 6);
+
+  return `${base}__${hashSuffix}`;
+}
+
+function escapeHtmlForMermaidLabel(value: string): string {
+  return value.replace(/[&<>"]/g, (character) => {
+    switch (character) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case "\"":
+        return "&quot;";
+      default:
+        return character;
+    }
+  });
 }
 
 function toMermaidLabel(subsystem: ArchitectureSubsystem): string {
-  return `${subsystem.id}<br/>${subsystem.inferred_responsibility}`.replace(/"/g, "&quot;");
+  const safeId = escapeHtmlForMermaidLabel(subsystem.id);
+  const safeResponsibility = escapeHtmlForMermaidLabel(subsystem.inferred_responsibility);
+
+  return `${safeId}<br/>${safeResponsibility}`;
 }
 
 function sortUniqueStrings(values: string[]): string[] {

--- a/src/core/operations/updateArchitectureDocs.ts
+++ b/src/core/operations/updateArchitectureDocs.ts
@@ -285,12 +285,10 @@ function renderArchitectureSummaryMarkdown(
   }
 
   const diagramsSection = renderArchitectureDiagramsMarkdown(repoProfile, architectureSummary);
-  if (diagramsSection.trim().length > 0) {
-    if (parts.length > 0) {
-      parts.push("");
-    }
-    parts.push(diagramsSection);
+  if (parts.length > 0) {
+    parts.push("");
   }
+  parts.push(diagramsSection);
 
   const evidenceSection = renderEvidenceSection(repoProfile, architectureSummary);
   if (evidenceSection.trim().length > 0) {

--- a/src/core/operations/updateArchitectureDocs.ts
+++ b/src/core/operations/updateArchitectureDocs.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { createDryRunReport, type DryRunReport } from "../contracts/dryRun.js";
 import type { ProjectMode } from "../contracts/domain.js";
 import type { OperationContract } from "../contracts/operation.js";
+import { renderArchitectureDiagramsMarkdown } from "./architectureDiagrams.js";
 import type { ArchitectureSummaryArtifact } from "./mapArchitectureFromRepo.js";
 import type { RepoProfileArtifact } from "./profileRepository.js";
 
@@ -70,6 +71,7 @@ export const UPDATE_ARCHITECTURE_DOCS_OPERATION_CONTRACT: OperationContract<
   ],
   invariants: [
     "Generated architecture docs are derived only from repo_profile and architecture_summary inputs.",
+    "Generated architecture docs include deterministic system-context and subsystem-relationship diagrams.",
     "Managed architecture doc sections preserve surrounding manual content.",
     "Evidence references remain visible in both summary markdown and maintained docs."
   ],
@@ -282,6 +284,14 @@ function renderArchitectureSummaryMarkdown(
     parts.push(architectureSummary.summary_markdown.trimEnd());
   }
 
+  const diagramsSection = renderArchitectureDiagramsMarkdown(repoProfile, architectureSummary);
+  if (diagramsSection.trim().length > 0) {
+    if (parts.length > 0) {
+      parts.push("");
+    }
+    parts.push(diagramsSection);
+  }
+
   const evidenceSection = renderEvidenceSection(repoProfile, architectureSummary);
   if (evidenceSection.trim().length > 0) {
     if (parts.length > 0) {
@@ -308,9 +318,14 @@ function renderManagedGeneratedSection(
   repoProfile: RepoProfileArtifact,
   architectureSummary: ArchitectureSummaryArtifact
 ): string {
+  const diagramsSection = renderArchitectureDiagramsMarkdown(repoProfile, architectureSummary);
+  const evidenceSection = renderEvidenceSection(repoProfile, architectureSummary);
+
   return [
     GENERATED_SECTION_START,
-    renderEvidenceSection(repoProfile, architectureSummary),
+    diagramsSection,
+    "",
+    evidenceSection,
     GENERATED_SECTION_END
   ].join("\n");
 }

--- a/tests/diagnostics/inspect.test.ts
+++ b/tests/diagnostics/inspect.test.ts
@@ -192,8 +192,14 @@ describe("runInspect success paths", () => {
     expect(await readFile(result.architecture_summary_markdown_path!, "utf8")).toContain(
       "## Artifact Flow"
     );
+    expect(await readFile(result.architecture_summary_markdown_path!, "utf8")).toContain(
+      "## System Context Diagram"
+    );
     expect(await readFile(result.architecture_docs_path!, "utf8")).toContain(
       "<!-- specforge:begin generated-architecture -->"
+    );
+    expect(await readFile(result.architecture_docs_path!, "utf8")).toContain(
+      "## Subsystem Relationship Diagram"
     );
 
     const report = formatInspectReport(result);

--- a/tests/diagnostics/risk-analysis.test.ts
+++ b/tests/diagnostics/risk-analysis.test.ts
@@ -166,10 +166,7 @@ function createRepoProfile(input: { sampled_files: string[] }): RepoProfileArtif
     evidence: {
       top_level_entries: ["src", "tests"],
       sampled_files: input.sampled_files,
-      extension_counts: [
-        { extension: ".test.ts", count: 1 },
-        { extension: ".ts", count: input.sampled_files.length - 1 }
-      ],
+      extension_counts: [{ extension: ".ts", count: input.sampled_files.length }],
       detected_manifests: ["package.json", "tsconfig.json"],
       detected_tooling: ["node", "typescript"]
     }

--- a/tests/documentation/architecture-diagrams.test.ts
+++ b/tests/documentation/architecture-diagrams.test.ts
@@ -58,6 +58,25 @@ describe("architecture diagram generation", () => {
     expect(markdown).toContain("src/api&lt;core&gt;<br/>API &amp; &quot;backend&quot; &lt;surface&gt;");
     expect(markdown).not.toContain('src/api<core><br/>API & "backend" <surface>');
   });
+
+  it("always emits fixed-width hash suffixes for mermaid node ids", () => {
+    const repoProfile = buildRepoProfile("/workspace/specforge");
+    const architectureSummary = buildArchitectureSummary("/workspace/specforge");
+    architectureSummary.subsystems = [
+      {
+        id: "a",
+        label: "a",
+        inferred_responsibility: "General subsystem",
+        file_count: 1,
+        evidence_refs: ["a.ts"],
+        uncertainty: "medium"
+      }
+    ];
+
+    const markdown = renderArchitectureDiagramsMarkdown(repoProfile, architectureSummary);
+
+    expect(markdown).toMatch(/a__[a-z0-9]{6}\["a<br\/>General subsystem"]/);
+  });
 });
 
 function buildRepoProfile(repositoryRoot: string): RepoProfileArtifact {

--- a/tests/documentation/architecture-diagrams.test.ts
+++ b/tests/documentation/architecture-diagrams.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { renderArchitectureDiagramsMarkdown } from "../../src/core/operations/architectureDiagrams.js";
+import type { ArchitectureSummaryArtifact } from "../../src/core/operations/mapArchitectureFromRepo.js";
+import type { RepoProfileArtifact } from "../../src/core/operations/profileRepository.js";
+
+describe("architecture diagram generation", () => {
+  it("renders deterministic mermaid diagrams and evidence-backed subsystem relationships", () => {
+    const repoProfile = buildRepoProfile("/workspace/specforge");
+    const architectureSummary = buildArchitectureSummary("/workspace/specforge");
+
+    const markdown = renderArchitectureDiagramsMarkdown(repoProfile, architectureSummary);
+
+    expect(markdown).toContain("## System Context Diagram");
+    expect(markdown).toContain("```mermaid");
+    expect(markdown).toContain('repository["Repository"]');
+    expect(markdown).toContain('src_api["src/api');
+    expect(markdown).toContain("repository --> src_api");
+    expect(markdown).toContain("repository --> src_cli");
+    expect(markdown).toContain("## Subsystem Relationship Diagram");
+    expect(markdown).toContain("src_cli --> src_api");
+    expect(markdown).toContain("tests_api -.-> src_api");
+    expect(markdown).toContain("### Relationship Evidence");
+    expect(markdown).toContain("src/cli -> src/api");
+    expect(markdown).toContain("tests/api -> src/api");
+    expect(markdown).toContain("src/api/routes.ts");
+    expect(markdown).toContain("tests/api/routes.test.ts");
+  });
+});
+
+function buildRepoProfile(repositoryRoot: string): RepoProfileArtifact {
+  return {
+    kind: "repo_profile",
+    metadata: {
+      artifact_id: "repo_profile",
+      artifact_version: "v1",
+      created_timestamp: "2026-03-16T00:00:00.000Z",
+      generator: "operation.profileRepository",
+      source_refs: [],
+      checksum: "a".repeat(64)
+    },
+    project_mode: "existing-repo",
+    repository_root: repositoryRoot,
+    scan: {
+      max_files: 200,
+      scanned_file_count: 4,
+      truncated: false,
+      ignored_directories: [".git", ".specforge"]
+    },
+    evidence: {
+      top_level_entries: ["src", "tests"],
+      sampled_files: [
+        "src/api/routes.ts",
+        "src/api/service.ts",
+        "src/cli/main.ts",
+        "tests/api/routes.test.ts"
+      ],
+      extension_counts: [
+        { extension: ".test.ts", count: 1 },
+        { extension: ".ts", count: 3 }
+      ],
+      detected_manifests: ["package.json"],
+      detected_tooling: ["node", "typescript", "vitest"]
+    }
+  };
+}
+
+function buildArchitectureSummary(repositoryRoot: string): ArchitectureSummaryArtifact {
+  return {
+    kind: "architecture_summary",
+    metadata: {
+      artifact_id: "architecture_summary",
+      artifact_version: "v1",
+      created_timestamp: "2026-03-16T00:00:05.000Z",
+      generator: "operation.mapArchitectureFromRepo",
+      source_refs: [{ artifact_id: "repo_profile", artifact_version: "v1" }],
+      checksum: "b".repeat(64)
+    },
+    project_mode: "existing-repo",
+    repository_root: repositoryRoot,
+    subsystems: [
+      {
+        id: "src/api",
+        label: "src/api",
+        inferred_responsibility: "API/backend surface",
+        file_count: 2,
+        evidence_refs: ["src/api/routes.ts", "src/api/service.ts"],
+        uncertainty: "low"
+      },
+      {
+        id: "src/cli",
+        label: "src/cli",
+        inferred_responsibility: "CLI entrypoints",
+        file_count: 1,
+        evidence_refs: ["src/cli/main.ts"],
+        uncertainty: "medium"
+      },
+      {
+        id: "tests/api",
+        label: "tests/api",
+        inferred_responsibility: "Test coverage",
+        file_count: 1,
+        evidence_refs: ["tests/api/routes.test.ts"],
+        uncertainty: "medium"
+      }
+    ],
+    summary_markdown: "# Architecture Summary"
+  };
+}

--- a/tests/documentation/architecture-diagrams.test.ts
+++ b/tests/documentation/architecture-diagrams.test.ts
@@ -106,10 +106,7 @@ function buildRepoProfile(repositoryRoot: string): RepoProfileArtifact {
         "src/cli/main.ts",
         "tests/api/routes.test.ts"
       ],
-      extension_counts: [
-        { extension: ".test.ts", count: 1 },
-        { extension: ".ts", count: 3 }
-      ],
+      extension_counts: [{ extension: ".ts", count: 4 }],
       detected_manifests: ["package.json"],
       detected_tooling: ["node", "typescript", "vitest"]
     }

--- a/tests/documentation/architecture-diagrams.test.ts
+++ b/tests/documentation/architecture-diagrams.test.ts
@@ -14,17 +14,49 @@ describe("architecture diagram generation", () => {
     expect(markdown).toContain("## System Context Diagram");
     expect(markdown).toContain("```mermaid");
     expect(markdown).toContain('repository["Repository"]');
-    expect(markdown).toContain('src_api["src/api');
-    expect(markdown).toContain("repository --> src_api");
-    expect(markdown).toContain("repository --> src_cli");
+    expect(markdown).toMatch(/src_api__[a-z0-9]{6}\["src\/api/);
+    expect(markdown).toMatch(/repository --> src_api__[a-z0-9]{6}/);
+    expect(markdown).toMatch(/repository --> src_cli__[a-z0-9]{6}/);
     expect(markdown).toContain("## Subsystem Relationship Diagram");
-    expect(markdown).toContain("src_cli --> src_api");
-    expect(markdown).toContain("tests_api -.-> src_api");
+    expect(markdown).toMatch(/src_cli__[a-z0-9]{6} --> src_api__[a-z0-9]{6}/);
+    expect(markdown).toMatch(/tests_api__[a-z0-9]{6} -.-> src_api__[a-z0-9]{6}/);
     expect(markdown).toContain("### Relationship Evidence");
     expect(markdown).toContain("src/cli -> src/api");
     expect(markdown).toContain("tests/api -> src/api");
     expect(markdown).toContain("src/api/routes.ts");
     expect(markdown).toContain("tests/api/routes.test.ts");
+  });
+
+  it("escapes mermaid labels and keeps node ids collision-safe", () => {
+    const repoProfile = buildRepoProfile("/workspace/specforge");
+    const architectureSummary = buildArchitectureSummary("/workspace/specforge");
+    architectureSummary.subsystems = [
+      {
+        id: 'src/api<core>',
+        label: 'src/api<core>',
+        inferred_responsibility: 'API & "backend" <surface>',
+        file_count: 1,
+        evidence_refs: ["src/api/index.ts"],
+        uncertainty: "medium"
+      },
+      {
+        id: "src_api<core>",
+        label: "src_api<core>",
+        inferred_responsibility: "General subsystem",
+        file_count: 1,
+        evidence_refs: ["src_api/index.ts"],
+        uncertainty: "medium"
+      }
+    ];
+
+    const markdown = renderArchitectureDiagramsMarkdown(repoProfile, architectureSummary);
+    const nodeIds = new Set(
+      [...markdown.matchAll(/^\s{2}(src_api_core__[a-z0-9]{6})\[/gm)].map(([, nodeId]) => nodeId)
+    );
+
+    expect(nodeIds.size).toBe(2);
+    expect(markdown).toContain("src/api&lt;core&gt;<br/>API &amp; &quot;backend&quot; &lt;surface&gt;");
+    expect(markdown).not.toContain('src/api<core><br/>API & "backend" <surface>');
   });
 });
 

--- a/tests/documentation/update-architecture-docs.test.ts
+++ b/tests/documentation/update-architecture-docs.test.ts
@@ -26,14 +26,22 @@ function buildRepoProfile(repositoryRoot: string): RepoProfileArtifact {
     repository_root: repositoryRoot,
     scan: {
       max_files: 200,
-      scanned_file_count: 3,
+      scanned_file_count: 4,
       truncated: false,
       ignored_directories: [".git", ".specforge"]
     },
     evidence: {
       top_level_entries: ["README.md", "docs", "src"],
-      sampled_files: ["src/api/routes.ts", "src/api/service.ts", "src/cli/main.ts"],
-      extension_counts: [{ extension: ".ts", count: 3 }],
+      sampled_files: [
+        "src/api/routes.ts",
+        "src/api/service.ts",
+        "src/cli/main.ts",
+        "tests/api/routes.test.ts"
+      ],
+      extension_counts: [
+        { extension: ".test.ts", count: 1 },
+        { extension: ".ts", count: 3 }
+      ],
       detected_manifests: ["package.json"],
       detected_tooling: ["node", "typescript", "vitest"]
     }
@@ -68,6 +76,14 @@ function buildArchitectureSummary(repositoryRoot: string): ArchitectureSummaryAr
         inferred_responsibility: "CLI entrypoints",
         file_count: 1,
         evidence_refs: ["src/cli/main.ts"],
+        uncertainty: "medium"
+      },
+      {
+        id: "tests/api",
+        label: "tests/api",
+        inferred_responsibility: "Test coverage",
+        file_count: 1,
+        evidence_refs: ["tests/api/routes.test.ts"],
         uncertainty: "medium"
       }
     ],
@@ -187,13 +203,19 @@ describe("updateArchitectureDocs success paths", () => {
     expect(result.architecture_docs_path).toBe(join(repoRoot, "docs", "ARCHITECTURE.md"));
     expect(result.architecture_summary_markdown).toContain("# Architecture Summary");
     expect(result.architecture_summary_markdown).toContain("## Artifact Flow");
+    expect(result.architecture_summary_markdown).toContain("## System Context Diagram");
+    expect(result.architecture_summary_markdown).toContain("## Subsystem Relationship Diagram");
     expect(result.architecture_summary_markdown).toContain("operation.profileRepository");
     expect(result.architecture_summary_markdown).toContain("src/api/routes.ts");
+    expect(result.architecture_summary_markdown).toContain("src_cli --> src_api");
+    expect(result.architecture_summary_markdown).toContain("tests_api -.-> src_api");
 
     const docsContent = await readFile(result.architecture_docs_path, "utf8");
     expect(docsContent).toContain("Manual overview.");
     expect(docsContent).toContain("<!-- specforge:begin generated-architecture -->");
     expect(docsContent).toContain("## Repository Evidence Snapshot");
+    expect(docsContent).toContain("## System Context Diagram");
+    expect(docsContent).toContain("## Subsystem Relationship Diagram");
     expect(docsContent).toContain("### Subsystem: src/api");
     expect(docsContent).toContain("### Contracts");
     expect(docsContent).toContain("### Artifact Flow");

--- a/tests/documentation/update-architecture-docs.test.ts
+++ b/tests/documentation/update-architecture-docs.test.ts
@@ -207,8 +207,12 @@ describe("updateArchitectureDocs success paths", () => {
     expect(result.architecture_summary_markdown).toContain("## Subsystem Relationship Diagram");
     expect(result.architecture_summary_markdown).toContain("operation.profileRepository");
     expect(result.architecture_summary_markdown).toContain("src/api/routes.ts");
-    expect(result.architecture_summary_markdown).toContain("src_cli --> src_api");
-    expect(result.architecture_summary_markdown).toContain("tests_api -.-> src_api");
+    expect(result.architecture_summary_markdown).toMatch(
+      /src_cli__[a-z0-9]{6} --> src_api__[a-z0-9]{6}/
+    );
+    expect(result.architecture_summary_markdown).toMatch(
+      /tests_api__[a-z0-9]{6} -.-> src_api__[a-z0-9]{6}/
+    );
 
     const docsContent = await readFile(result.architecture_docs_path, "utf8");
     expect(docsContent).toContain("Manual overview.");

--- a/tests/documentation/update-architecture-docs.test.ts
+++ b/tests/documentation/update-architecture-docs.test.ts
@@ -38,10 +38,7 @@ function buildRepoProfile(repositoryRoot: string): RepoProfileArtifact {
         "src/cli/main.ts",
         "tests/api/routes.test.ts"
       ],
-      extension_counts: [
-        { extension: ".test.ts", count: 1 },
-        { extension: ".ts", count: 3 }
-      ],
+      extension_counts: [{ extension: ".ts", count: 4 }],
       detected_manifests: ["package.json"],
       detected_tooling: ["node", "typescript", "vitest"]
     }


### PR DESCRIPTION
## Summary
- add deterministic Mermaid system-context and subsystem-relationship diagram generation from inspect artifacts
- embed the generated diagrams into architecture summary markdown and managed docs output
- cover the new rendering path with diagram, documentation, and inspect integration tests

Closes #48