### PR TITLE
feat: add status notifier adapters

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -197,7 +197,7 @@ The command reads artifact inputs and optional policy/schedule context, then pri
     .option("--repo <owner/repo>", "GitHub repository slug when --pr is not a pull request URL")
     .option(
       "--notify-webhook <url>",
-      "Emit the status event to a webhook without failing the status command if delivery fails",
+      "Emit the status event to a webhook; delivery failures are reported without failing the status command, but invalid webhook configuration is still an error",
       collectOptionValues,
       []
     )

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import {
   type RunStatusInput,
   type StatusResult
 } from "./core/diagnostics/status.js";
+import { createWebhookStatusNotifier } from "./core/notifiers/statusNotifiers.js";
 
 interface CliWriter {
   write(chunk: string): boolean | void;
@@ -194,21 +195,38 @@ The command reads artifact inputs and optional policy/schedule context, then pri
     .description("Report GitHub pull request state and CI outcomes. Example: specforge status --repo iKwesi/SpecForge --pr 123")
     .requiredOption("--pr <ref>", "Pull request number, URL, or branch to inspect")
     .option("--repo <owner/repo>", "GitHub repository slug when --pr is not a pull request URL")
+    .option(
+      "--notify-webhook <url>",
+      "Emit the status event to a webhook without failing the status command if delivery fails",
+      collectOptionValues,
+      []
+    )
     .addHelpText(
       "after",
       `
 Examples:
   $ specforge status --repo iKwesi/SpecForge --pr 123
   $ specforge status --pr https://github.com/iKwesi/SpecForge/pull/123
+  $ specforge status --repo iKwesi/SpecForge --pr 123 --notify-webhook https://hooks.example.test/specforge
 
 Use this after PR handoff when you need the latest GitHub merge state and status checks.
 `
     )
-    .action(async (options: { pr: string; repo?: string }) => {
+    .action(async (options: { pr: string; repo?: string; notifyWebhook: string[] }) => {
       try {
         const result = await statusRunner({
           pull_request: options.pr,
           ...(options.repo ? { repository: options.repo } : {}),
+          ...(options.notifyWebhook.length > 0
+            ? {
+                notifiers: options.notifyWebhook.map((webhookUrl, index) =>
+                  createWebhookStatusNotifier({
+                    webhook_url: webhookUrl,
+                    adapter_id: options.notifyWebhook.length > 1 ? `webhook-${index + 1}` : "webhook"
+                  })
+                )
+              }
+            : {}),
           ...(statusInput ?? {})
         });
 

--- a/src/core/diagnostics/status.ts
+++ b/src/core/diagnostics/status.ts
@@ -4,13 +4,21 @@ import {
   type GitHubProvider,
   type GitHubPullRequestStatus
 } from "../github/provider.js";
+import {
+  emitStatusNotification,
+  type StatusNotificationDelivery,
+  type StatusNotifier
+} from "../notifiers/statusNotifiers.js";
 
 export interface RunStatusInput extends GetPullRequestStatusInput {
   github_provider?: GitHubProvider;
+  notifiers?: StatusNotifier[];
+  emitted_at?: Date;
 }
 
 export interface StatusResult {
   pull_request: GitHubPullRequestStatus;
+  notification_deliveries?: StatusNotificationDelivery[];
 }
 
 /**
@@ -25,9 +33,19 @@ export async function runStatus(input: RunStatusInput): Promise<StatusResult> {
     pull_request: input.pull_request,
     ...(input.repository ? { repository: input.repository } : {})
   });
+  const notificationDeliveries =
+    input.notifiers && input.notifiers.length > 0
+      ? await emitStatusNotification({
+          pull_request: pullRequest,
+          ...(input.repository ? { repository: input.repository } : {}),
+          ...(input.emitted_at ? { emitted_at: input.emitted_at } : {}),
+          notifiers: input.notifiers
+        })
+      : undefined;
 
   return {
-    pull_request: pullRequest
+    pull_request: pullRequest,
+    ...(notificationDeliveries ? { notification_deliveries: notificationDeliveries } : {})
   };
 }
 
@@ -59,6 +77,19 @@ export function formatStatusReport(result: StatusResult): string {
       lines.push(
         `- ${statusCheck.name} [${statusCheck.type}] ${statusCheck.status}/${statusCheck.conclusion}`
       );
+    }
+  }
+
+  if (result.notification_deliveries) {
+    lines.push("", "Notifications");
+    if (result.notification_deliveries.length === 0) {
+      lines.push("- none");
+    } else {
+      for (const delivery of result.notification_deliveries) {
+        lines.push(
+          `- ${delivery.adapter_id} ${delivery.delivery_status}: ${delivery.message}`
+        );
+      }
     }
   }
 

--- a/src/core/notifiers/statusNotifiers.ts
+++ b/src/core/notifiers/statusNotifiers.ts
@@ -100,25 +100,24 @@ export async function emitStatusNotification(
     pull_request: input.pull_request
   };
 
-  const deliveries: StatusNotificationDelivery[] = [];
-  for (const notifier of input.notifiers) {
-    try {
-      await notifier.notify(event);
-      deliveries.push({
-        adapter_id: notifier.adapter_id,
-        delivery_status: "delivered",
-        message: "Status event delivered."
-      });
-    } catch (error) {
-      deliveries.push({
-        adapter_id: notifier.adapter_id,
-        delivery_status: "failed",
-        message: error instanceof Error ? error.message : String(error)
-      });
-    }
-  }
-
-  return deliveries;
+  return Promise.all(
+    input.notifiers.map(async (notifier) => {
+      try {
+        await notifier.notify(event);
+        return {
+          adapter_id: notifier.adapter_id,
+          delivery_status: "delivered",
+          message: "Status event delivered."
+        } as StatusNotificationDelivery;
+      } catch (error) {
+        return {
+          adapter_id: notifier.adapter_id,
+          delivery_status: "failed",
+          message: error instanceof Error ? error.message : String(error)
+        } as StatusNotificationDelivery;
+      }
+    })
+  );
 }
 
 function normalizeWebhookUrl(value: string): string {
@@ -151,11 +150,12 @@ function normalizeWebhookUrl(value: string): string {
   return url.toString();
 }
 
-function normalizeAdapterId(value: string): string {
-  if (value.trim().length === 0) {
+function normalizeAdapterId(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
     throw new StatusNotifierError(
       "invalid_notifier",
-      "adapter_id must be a non-empty string."
+      "adapter_id must be a non-empty string.",
+      { adapter_id: value }
     );
   }
 

--- a/src/core/notifiers/statusNotifiers.ts
+++ b/src/core/notifiers/statusNotifiers.ts
@@ -108,13 +108,13 @@ export async function emitStatusNotification(
           adapter_id: notifier.adapter_id,
           delivery_status: "delivered",
           message: "Status event delivered."
-        } as StatusNotificationDelivery;
+        };
       } catch (error) {
         return {
           adapter_id: notifier.adapter_id,
           delivery_status: "failed",
           message: error instanceof Error ? error.message : String(error)
-        } as StatusNotificationDelivery;
+        };
       }
     })
   );

--- a/src/core/notifiers/statusNotifiers.ts
+++ b/src/core/notifiers/statusNotifiers.ts
@@ -1,0 +1,179 @@
+import type { GitHubPullRequestStatus } from "../github/provider.js";
+
+export type StatusNotifierErrorCode = "invalid_notifier" | "delivery_failed";
+
+export class StatusNotifierError extends Error {
+  readonly code: StatusNotifierErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: StatusNotifierErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "StatusNotifierError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface PullRequestStatusNotificationEvent {
+  event_kind: "pull_request_status";
+  emitted_at: string;
+  repository?: string;
+  pull_request: GitHubPullRequestStatus;
+}
+
+export type StatusNotificationEvent = PullRequestStatusNotificationEvent;
+
+export interface StatusNotifier {
+  adapter_id: string;
+  notify(event: StatusNotificationEvent): Promise<void>;
+}
+
+export interface StatusNotificationDelivery {
+  adapter_id: string;
+  delivery_status: "delivered" | "failed";
+  message: string;
+}
+
+export interface EmitStatusNotificationInput {
+  pull_request: GitHubPullRequestStatus;
+  repository?: string;
+  emitted_at?: Date;
+  notifiers: StatusNotifier[];
+}
+
+type FetchLike = (input: string, init?: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}) => Promise<{ ok: boolean; status: number }>;
+
+export function createWebhookStatusNotifier(input: {
+  webhook_url: string;
+  adapter_id?: string;
+  fetch?: FetchLike;
+}): StatusNotifier {
+  const webhookUrl = normalizeWebhookUrl(input.webhook_url);
+  const adapterId = normalizeAdapterId(input.adapter_id ?? "webhook");
+  const fetchImpl = input.fetch ?? resolveGlobalFetch();
+
+  return {
+    adapter_id: adapterId,
+    async notify(event) {
+      try {
+        const response = await fetchImpl(webhookUrl, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-specforge-event-kind": event.event_kind
+          },
+          body: JSON.stringify(event)
+        });
+
+        if (!response.ok) {
+          throw new StatusNotifierError(
+            "delivery_failed",
+            `Webhook delivery failed with HTTP ${response.status}.`
+          );
+        }
+      } catch (error) {
+        if (error instanceof StatusNotifierError) {
+          throw error;
+        }
+
+        throw new StatusNotifierError(
+          "delivery_failed",
+          error instanceof Error ? error.message : String(error),
+          error
+        );
+      }
+    }
+  };
+}
+
+export async function emitStatusNotification(
+  input: EmitStatusNotificationInput
+): Promise<StatusNotificationDelivery[]> {
+  const event: StatusNotificationEvent = {
+    event_kind: "pull_request_status",
+    emitted_at: (input.emitted_at ?? new Date()).toISOString(),
+    ...(input.repository ? { repository: input.repository } : {}),
+    pull_request: input.pull_request
+  };
+
+  const deliveries: StatusNotificationDelivery[] = [];
+  for (const notifier of input.notifiers) {
+    try {
+      await notifier.notify(event);
+      deliveries.push({
+        adapter_id: notifier.adapter_id,
+        delivery_status: "delivered",
+        message: "Status event delivered."
+      });
+    } catch (error) {
+      deliveries.push({
+        adapter_id: notifier.adapter_id,
+        delivery_status: "failed",
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  return deliveries;
+}
+
+function normalizeWebhookUrl(value: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new StatusNotifierError(
+      "invalid_notifier",
+      "webhook_url must be a non-empty http(s) URL."
+    );
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new StatusNotifierError(
+      "invalid_notifier",
+      "webhook_url must be a valid http(s) URL.",
+      error
+    );
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new StatusNotifierError(
+      "invalid_notifier",
+      "webhook_url must use http or https."
+    );
+  }
+
+  return url.toString();
+}
+
+function normalizeAdapterId(value: string): string {
+  if (value.trim().length === 0) {
+    throw new StatusNotifierError(
+      "invalid_notifier",
+      "adapter_id must be a non-empty string."
+    );
+  }
+
+  return value.trim();
+}
+
+function resolveGlobalFetch(): FetchLike {
+  if (typeof globalThis.fetch !== "function") {
+    throw new StatusNotifierError(
+      "invalid_notifier",
+      "Global fetch is unavailable; provide a fetch implementation explicitly."
+    );
+  }
+
+  return async (input, init) => {
+    const response = await globalThis.fetch(input, init);
+    return {
+      ok: response.ok,
+      status: response.status
+    };
+  };
+}

--- a/src/core/notifiers/statusNotifiers.ts
+++ b/src/core/notifiers/statusNotifiers.ts
@@ -128,10 +128,11 @@ function normalizeWebhookUrl(value: string): string {
       "webhook_url must be a non-empty http(s) URL."
     );
   }
+  const trimmed = value.trim();
 
   let url: URL;
   try {
-    url = new URL(value);
+    url = new URL(trimmed);
   } catch (error) {
     throw new StatusNotifierError(
       "invalid_notifier",

--- a/tests/cli/status-command.test.ts
+++ b/tests/cli/status-command.test.ts
@@ -25,35 +25,66 @@ function buildStatusResult(): StatusResult {
           details_url: "https://example.com/build"
         }
       ]
-    }
+    },
+    notification_deliveries: [
+      {
+        adapter_id: "webhook",
+        delivery_status: "delivered",
+        message: "Status event delivered."
+      }
+    ]
   };
 }
 
 describe("sf status command", () => {
   it("prints pull request status details and exits cleanly", async () => {
     let stdout = "";
-    let receivedInput: { repository?: string; pull_request?: string } | undefined;
+    let receivedInput:
+      | { repository?: string; pull_request: string; notifiers?: Array<{ adapter_id: string }> }
+      | undefined;
 
-    const exitCode = await runCli(["node", "sf", "status", "--repo", "iKwesi/SpecForge", "--pr", "123"], {
-      stdout: {
-        write(chunk: string) {
-          stdout += chunk;
-          return true;
+    const exitCode = await runCli(
+      [
+        "node",
+        "sf",
+        "status",
+        "--repo",
+        "iKwesi/SpecForge",
+        "--pr",
+        "123",
+        "--notify-webhook",
+        "https://hooks.example.test/specforge"
+      ],
+      {
+        stdout: {
+          write(chunk: string) {
+            stdout += chunk;
+            return true;
+          }
+        },
+        status_runner: async (input) => {
+          receivedInput = {
+            pull_request: input.pull_request,
+            ...(input.repository ? { repository: input.repository } : {}),
+            ...(input.notifiers
+              ? { notifiers: input.notifiers.map((notifier) => ({ adapter_id: notifier.adapter_id })) }
+              : {})
+          };
+          return buildStatusResult();
         }
-      },
-      status_runner: async (input) => {
-        receivedInput = input;
-        return buildStatusResult();
       }
-    });
+    );
 
     expect(exitCode).toBe(0);
     expect(receivedInput).toEqual({
       repository: "iKwesi/SpecForge",
-      pull_request: "123"
+      pull_request: "123",
+      notifiers: [{ adapter_id: "webhook" }]
     });
     expect(stdout).toContain("SpecForge Status");
     expect(stdout).toContain("Pull Request: #123");
+    expect(stdout).toContain("Notifications");
+    expect(stdout).toContain("- webhook delivered: Status event delivered.");
   });
 
   it("returns exit code 1 when the status command fails", async () => {

--- a/tests/diagnostics/status.test.ts
+++ b/tests/diagnostics/status.test.ts
@@ -7,6 +7,48 @@ describe("runStatus", () => {
     const result = await runStatus({
       repository: "iKwesi/SpecForge",
       pull_request: "123",
+      emitted_at: new Date("2026-03-16T00:10:00.000Z"),
+      notifiers: [
+        {
+          adapter_id: "webhook",
+          async notify(event) {
+            expect(event).toEqual({
+              event_kind: "pull_request_status",
+              emitted_at: "2026-03-16T00:10:00.000Z",
+              repository: "iKwesi/SpecForge",
+              pull_request: {
+                number: 123,
+                url: "https://github.com/iKwesi/SpecForge/pull/123",
+                title: "feat: implement task flow",
+                state: "open",
+                merge_state_status: "clean",
+                head_branch: "feat/task-1",
+                base_branch: "main",
+                linked_issue_numbers: [40],
+                overall_status: "failure",
+                status_checks: [
+                  {
+                    name: "build",
+                    type: "check_run",
+                    status: "completed",
+                    conclusion: "success",
+                    workflow_name: "ci",
+                    details_url: "https://example.com/build"
+                  },
+                  {
+                    name: "policy",
+                    type: "check_run",
+                    status: "completed",
+                    conclusion: "failure",
+                    workflow_name: "ci",
+                    details_url: "https://example.com/policy"
+                  }
+                ]
+              }
+            });
+          }
+        }
+      ],
       github_provider: {
         async isAvailable() {
           return true;
@@ -50,6 +92,13 @@ describe("runStatus", () => {
 
     expect(result.pull_request.number).toBe(123);
     expect(result.pull_request.overall_status).toBe("failure");
+    expect(result.notification_deliveries).toEqual([
+      {
+        adapter_id: "webhook",
+        delivery_status: "delivered",
+        message: "Status event delivered."
+      }
+    ]);
 
     const report = formatStatusReport(result);
     expect(report).toContain("SpecForge Status");
@@ -57,5 +106,52 @@ describe("runStatus", () => {
     expect(report).toContain("Overall Status: failure");
     expect(report).toContain("Linked Issues: #40");
     expect(report).toContain("- policy [check_run] completed/failure");
+    expect(report).toContain("Notifications");
+    expect(report).toContain("- webhook delivered: Status event delivered.");
+  });
+
+  it("keeps status reporting successful when notifier delivery fails", async () => {
+    const result = await runStatus({
+      repository: "iKwesi/SpecForge",
+      pull_request: "123",
+      notifiers: [
+        {
+          adapter_id: "webhook",
+          async notify() {
+            throw new Error("webhook timed out");
+          }
+        }
+      ],
+      github_provider: {
+        async isAvailable() {
+          return true;
+        },
+        async createPullRequest() {
+          throw new Error("not used");
+        },
+        async getPullRequestStatus() {
+          return {
+            number: 123,
+            url: "https://github.com/iKwesi/SpecForge/pull/123",
+            title: "feat: implement task flow",
+            state: "open",
+            merge_state_status: "clean",
+            head_branch: "feat/task-1",
+            base_branch: "main",
+            linked_issue_numbers: [],
+            overall_status: "success",
+            status_checks: []
+          };
+        }
+      }
+    });
+
+    expect(result.notification_deliveries).toEqual([
+      {
+        adapter_id: "webhook",
+        delivery_status: "failed",
+        message: "webhook timed out"
+      }
+    ]);
   });
 });

--- a/tests/notifications/status-notifiers.test.ts
+++ b/tests/notifications/status-notifiers.test.ts
@@ -118,6 +118,68 @@ describe("status notifier adapters", () => {
     ]);
     expect(calls).toEqual(["https://hooks.example.test/specforge"]);
   });
+
+  it("rejects non-string adapter ids with a typed error", () => {
+    expect(() =>
+      createWebhookStatusNotifier({
+        webhook_url: "https://hooks.example.test/specforge",
+        adapter_id: 42 as never
+      })
+    ).toThrowError(
+      expect.objectContaining<Partial<StatusNotifierError>>({
+        code: "invalid_notifier",
+        details: { adapter_id: 42 }
+      })
+    );
+  });
+
+  it("delivers notifications concurrently while preserving result order", async () => {
+    const sequence: string[] = [];
+    let releaseSlowNotifier: (() => void) | undefined;
+    const slowNotifierReady = new Promise<void>((resolve) => {
+      releaseSlowNotifier = resolve;
+    });
+
+    const deliveriesPromise = emitStatusNotification({
+      pull_request: buildPullRequestStatus(),
+      notifiers: [
+        {
+          adapter_id: "slow-webhook",
+          async notify() {
+            sequence.push("slow-start");
+            await slowNotifierReady;
+            sequence.push("slow-end");
+          }
+        },
+        {
+          adapter_id: "fast-webhook",
+          async notify() {
+            sequence.push("fast-start");
+          }
+        }
+      ]
+    });
+
+    await Promise.resolve();
+    expect(sequence).toEqual(["slow-start", "fast-start"]);
+
+    releaseSlowNotifier?.();
+    const deliveries = await deliveriesPromise;
+
+    expect(deliveries).toEqual([
+      {
+        adapter_id: "slow-webhook",
+        delivery_status: "delivered",
+        message: "Status event delivered."
+      },
+      {
+        adapter_id: "fast-webhook",
+        delivery_status: "delivered",
+        message: "Status event delivered."
+      }
+    ]);
+    expect(sequence).toEqual(["slow-start", "fast-start", "slow-end"]);
+  });
 });
 
 function buildPullRequestStatus(): GitHubPullRequestStatus {

--- a/tests/notifications/status-notifiers.test.ts
+++ b/tests/notifications/status-notifiers.test.ts
@@ -93,6 +93,31 @@ describe("status notifier adapters", () => {
       })
     );
   });
+
+  it("accepts valid webhook urls even when copy-pasted with surrounding whitespace", async () => {
+    const calls: string[] = [];
+    const notifier = createWebhookStatusNotifier({
+      webhook_url: "  https://hooks.example.test/specforge  ",
+      fetch: async (url) => {
+        calls.push(String(url));
+        return new Response(null, { status: 204 });
+      }
+    });
+
+    const deliveries = await emitStatusNotification({
+      pull_request: buildPullRequestStatus(),
+      notifiers: [notifier]
+    });
+
+    expect(deliveries).toEqual([
+      {
+        adapter_id: "webhook",
+        delivery_status: "delivered",
+        message: "Status event delivered."
+      }
+    ]);
+    expect(calls).toEqual(["https://hooks.example.test/specforge"]);
+  });
 });
 
 function buildPullRequestStatus(): GitHubPullRequestStatus {

--- a/tests/notifications/status-notifiers.test.ts
+++ b/tests/notifications/status-notifiers.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  StatusNotifierError,
+  createWebhookStatusNotifier,
+  emitStatusNotification
+} from "../../src/core/notifiers/statusNotifiers.js";
+import type { GitHubPullRequestStatus } from "../../src/core/github/provider.js";
+
+describe("status notifier adapters", () => {
+  it("posts pull request status events to a webhook adapter", async () => {
+    const calls: Array<{
+      url: string;
+      method: string;
+      headers: HeadersInit | undefined;
+      body: string;
+    }> = [];
+    const notifier = createWebhookStatusNotifier({
+      webhook_url: "https://hooks.example.test/specforge",
+      fetch: async (url, init) => {
+        calls.push({
+          url: String(url),
+          method: init?.method ?? "GET",
+          headers: init?.headers,
+          body: String(init?.body ?? "")
+        });
+
+        return new Response(null, { status: 204 });
+      }
+    });
+
+    const deliveries = await emitStatusNotification({
+      pull_request: buildPullRequestStatus(),
+      repository: "iKwesi/SpecForge",
+      emitted_at: new Date("2026-03-16T00:00:00.000Z"),
+      notifiers: [notifier]
+    });
+
+    expect(deliveries).toEqual([
+      {
+        adapter_id: "webhook",
+        delivery_status: "delivered",
+        message: "Status event delivered."
+      }
+    ]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      url: "https://hooks.example.test/specforge",
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-specforge-event-kind": "pull_request_status"
+      },
+      body: JSON.stringify({
+        event_kind: "pull_request_status",
+        emitted_at: "2026-03-16T00:00:00.000Z",
+        repository: "iKwesi/SpecForge",
+        pull_request: buildPullRequestStatus()
+      })
+    });
+  });
+
+  it("isolates notifier delivery failures instead of throwing from the status flow", async () => {
+    const deliveries = await emitStatusNotification({
+      pull_request: buildPullRequestStatus(),
+      notifiers: [
+        {
+          adapter_id: "unstable-webhook",
+          async notify() {
+            throw new Error("socket hang up");
+          }
+        }
+      ]
+    });
+
+    expect(deliveries).toEqual([
+      {
+        adapter_id: "unstable-webhook",
+        delivery_status: "failed",
+        message: "socket hang up"
+      }
+    ]);
+  });
+
+  it("rejects invalid webhook urls with a typed error", () => {
+    expect(() =>
+      createWebhookStatusNotifier({
+        webhook_url: "ftp://hooks.example.test/specforge"
+      })
+    ).toThrowError(
+      expect.objectContaining<Partial<StatusNotifierError>>({
+        code: "invalid_notifier"
+      })
+    );
+  });
+});
+
+function buildPullRequestStatus(): GitHubPullRequestStatus {
+  return {
+    number: 123,
+    url: "https://github.com/iKwesi/SpecForge/pull/123",
+    title: "feat: implement task flow",
+    state: "open",
+    merge_state_status: "clean",
+    head_branch: "feat/task-1",
+    base_branch: "main",
+    linked_issue_numbers: [40],
+    overall_status: "success",
+    status_checks: [
+      {
+        name: "build",
+        type: "check_run",
+        status: "completed",
+        conclusion: "success",
+        workflow_name: "ci",
+        details_url: "https://example.com/build"
+      }
+    ]
+  };
+}

--- a/tests/notifications/status-notifiers.test.ts
+++ b/tests/notifications/status-notifiers.test.ts
@@ -82,6 +82,26 @@ describe("status notifier adapters", () => {
     ]);
   });
 
+  it("marks non-2xx webhook responses as failed deliveries", async () => {
+    const notifier = createWebhookStatusNotifier({
+      webhook_url: "https://hooks.example.test/specforge",
+      fetch: async () => new Response(null, { status: 500 })
+    });
+
+    const deliveries = await emitStatusNotification({
+      pull_request: buildPullRequestStatus(),
+      notifiers: [notifier]
+    });
+
+    expect(deliveries).toEqual([
+      {
+        adapter_id: "webhook",
+        delivery_status: "failed",
+        message: "Webhook delivery failed with HTTP 500."
+      }
+    ]);
+  });
+
   it("rejects invalid webhook urls with a typed error", () => {
     expect(() =>
       createWebhookStatusNotifier({


### PR DESCRIPTION
## Summary
- add provider-agnostic status notifier adapters with a concrete webhook notifier
- emit pull request status events from runStatus with delivery failure isolation
- wire the status CLI to optional --notify-webhook adapters and report notification outcomes

Closes #47